### PR TITLE
refactor: 일정 페이지 UI 개선

### DIFF
--- a/src/app/[id]/events/[eventId]/page.tsx
+++ b/src/app/[id]/events/[eventId]/page.tsx
@@ -21,10 +21,10 @@ export default function EventDetailPage() {
   }
 
   return (
-    <div className="px-1">
+    <div className="pt-5 px-1">
       {/* 제목 */}
       <div className="flex items-center gap-2.5 pb-5 border-b border-zinc-100">
-        <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#3b82f6" strokeWidth={1.8} className="shrink-0">
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8} className="shrink-0">
           <path strokeLinecap="round" strokeLinejoin="round"
             d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
         </svg>

--- a/src/app/[id]/events/page.tsx
+++ b/src/app/[id]/events/page.tsx
@@ -16,7 +16,7 @@ export default function EventsPage() {
   return (
     <div className="space-y-4">
       {/* 서브 탭 */}
-      <div className="flex justify-center border-b border-zinc-200 -mx-4 px-4">
+      <div className="flex justify-center border-b border-zinc-200 -mx-4 px-4 sticky top-0 z-10 bg-white">
         {(['다가오는 일정', '지난 일정'] as const).map((t) => (
           <button
             key={t}

--- a/src/app/[id]/events/page.tsx
+++ b/src/app/[id]/events/page.tsx
@@ -14,26 +14,26 @@ export default function EventsPage() {
   const events = tab === '다가오는 일정' ? UPCOMING : PAST;
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col min-h-full">
       {/* 서브 탭 */}
-      <div className="flex justify-center border-b border-zinc-200 -mx-4 px-4 sticky top-0 z-10 bg-white">
+      <div className="flex border-b border-zinc-200 -mx-4 sticky top-0 z-10 bg-white">
         {(['다가오는 일정', '지난 일정'] as const).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
-            className={`pb-2.5 mx-5 text-[13px] font-medium transition-colors whitespace-nowrap ${
-              tab === t
-                ? 'text-zinc-900 border-b-2 border-zinc-900 -mb-px'
-                : 'text-zinc-400'
+            className={`flex-1 flex justify-center text-[13px] font-medium transition-colors whitespace-nowrap ${
+              tab === t ? 'text-zinc-900' : 'text-zinc-400'
             }`}
           >
-            {t}
+            <span className={`inline-block py-2.5 -mb-px ${tab === t ? 'border-b-2 border-zinc-900' : ''}`}>
+              {t}
+            </span>
           </button>
         ))}
       </div>
 
       {/* 일정 목록 */}
-      <div className="pt-1">
+      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-6">
         {events.length === 0 && (
           <p className="text-center text-[13px] text-zinc-400 py-10">일정이 없습니다.</p>
         )}
@@ -51,7 +51,7 @@ export default function EventsPage() {
                   {/* 월 레이블 */}
                   <div className="relative z-10 flex flex-col items-center w-9 shrink-0">
                     {isFirstOfMonth ? (
-                      <div className="flex flex-col items-center bg-white">
+                      <div className="flex flex-col items-center bg-zinc-100">
                         <span className="text-[22px] font-bold leading-none text-zinc-800">{event.month}</span>
                         <span className="text-[11px] text-zinc-400 mt-0.5">월</span>
                       </div>
@@ -62,8 +62,8 @@ export default function EventsPage() {
 
                   {/* 카드 */}
                   <Link href={`/${id}/events/${event.id}`} className="flex-1">
-                    <div className="bg-white border border-zinc-200 rounded-xl px-4 py-3.5 shadow-sm active:bg-zinc-50 transition-colors">
-                      <p className="text-[12px] font-semibold text-blue-500">
+                    <div className="bg-white rounded-lg px-4 py-3.5 active:bg-zinc-50 transition-colors">
+                      <p className="text-[12px] font-semibold text-[#3B3EFF]">
                         {event.dateNum}일 {event.dateDay}
                       </p>
                       <p className="text-[14px] font-semibold text-zinc-900 mt-1">{event.title}</p>


### PR DESCRIPTION
## Summary
- 탭바 sticky 고정 (스크롤 시 탭 유지)
- 일정 상세 상단 pt-5 여백 추가
- 아이콘 컬러 통일 (#3B3EFF)

Related: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)