### PR TITLE
feat: 회의록 목록/생성/상세 페이지 구현

### DIFF
--- a/src/app/[id]/_components/GroupHeader.tsx
+++ b/src/app/[id]/_components/GroupHeader.tsx
@@ -1,21 +1,24 @@
 'use client';
 
 import { useRouter, usePathname } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
 
 export default function GroupHeader() {
   const router = useRouter();
   const pathname = usePathname();
+  const { editSlot } = useHeaderSlotStore();
 
   const segments = pathname.split('/');
   let backHref = '/main';
-  if (segments.length === 4) {
+  if (segments.length >= 4) {
     if (pathname.includes('/events/')) backHref = `/${segments[1]}/events`;
     else if (pathname.includes('/notices/')) backHref = `/${segments[1]}/notices`;
     else if (pathname.includes('/votes/')) backHref = `/${segments[1]}/votes`;
+    else if (pathname.includes('/minutes/')) backHref = `/${segments[1]}/minutes`;
   }
 
   return (
-    <header className="flex items-center justify-between px-4 py-3 border-b border-zinc-100 bg-white">
+    <header className="flex items-center justify-between px-4 h-[52px] shrink-0 border-b border-zinc-100 bg-white">
       <div className="flex items-center gap-2">
         <button onClick={() => router.push(backHref)} className="p-1 text-zinc-500">
           <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
@@ -24,11 +27,36 @@ export default function GroupHeader() {
         </button>
         <span className="text-[17px] font-bold tracking-tight">모임명</span>
       </div>
-      <button className="p-1 text-zinc-700">
-        <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
+      {editSlot ? (
+        editSlot.editing ? (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={editSlot.onCancel}
+              className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1"
+            >
+              취소
+            </button>
+            <button
+              onClick={editSlot.onSave}
+              className="text-[13px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3 py-1"
+            >
+              저장
+            </button>
+          </div>
+        ) : (
+          <button onClick={editSlot.onEdit} className="p-1 text-zinc-600">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 16H9v-3z" />
+            </svg>
+          </button>
+        )
+      ) : (
+        <button className="p-1 text-zinc-700">
+          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      )}
     </header>
   );
 }

--- a/src/app/[id]/_components/GroupNav.tsx
+++ b/src/app/[id]/_components/GroupNav.tsx
@@ -19,8 +19,8 @@ export default function GroupNav({ groupId }: { groupId: string }) {
 
   const segments = pathname.split('/');
   const isDetailPage =
-    segments.length === 4 &&
-    (pathname.includes('/events/') || pathname.includes('/notices/') || pathname.includes('/votes/'));
+    segments.length >= 4 &&
+    (pathname.includes('/events/') || pathname.includes('/notices/') || pathname.includes('/votes/') || pathname.includes('/minutes/'));
   if (isDetailPage) return null;
 
   return (

--- a/src/app/[id]/minutes/[minuteId]/page.tsx
+++ b/src/app/[id]/minutes/[minuteId]/page.tsx
@@ -1,0 +1,410 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { MINUTE_DETAILS, ScriptEntry } from '../_data';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+type TabType = '요약' | '스크립트' | '정보';
+
+const SPEAKER_COLORS = [
+  { bg: '#3B3EFF', text: '#fff' },
+  { bg: '#FF9E6A', text: '#fff' },
+  { bg: '#57B37A', text: '#fff' },
+  { bg: '#E5638C', text: '#fff' },
+  { bg: '#31DBD5', text: '#fff' },
+];
+
+function getSpeakerColor(index: number) {
+  return SPEAKER_COLORS[(index - 1) % SPEAKER_COLORS.length];
+}
+
+function SpeakerBadge({ index, name, wrap = false }: { index: number; name: string; wrap?: boolean }) {
+  const { bg, text } = getSpeakerColor(index);
+  return (
+    <span
+      className={`text-[11px] font-semibold px-2 py-0.5 inline-block ${wrap ? 'rounded-full break-all' : 'rounded-full shrink-0'}`}
+      style={{ backgroundColor: bg, color: text }}
+    >
+      {name}
+    </span>
+  );
+}
+
+function EditableSpeakerBadge({
+  index, name, editable, onRename,
+}: { index: number; name: string; editable: boolean; onRename: (name: string) => void }) {
+  const { bg, text } = getSpeakerColor(index);
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(name);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { setValue(name); }, [name]);
+
+  function commit() {
+    const trimmed = value.trim();
+    if (trimmed) onRename(trimmed);
+    else setValue(name);
+    setIsEditing(false);
+  }
+
+  if (editable && isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit();
+          if (e.key === 'Escape') { setValue(name); setIsEditing(false); }
+        }}
+        className="text-[11px] font-semibold px-2 py-0.5 rounded-full outline-none w-16 text-center"
+        style={{ backgroundColor: bg, color: text }}
+        autoFocus
+      />
+    );
+  }
+
+  return (
+    <button
+      onClick={() => { if (editable) { setValue(name); setIsEditing(true); } }}
+      className={`text-[11px] font-semibold px-2 py-0.5 rounded-full shrink-0 ${editable ? '' : 'cursor-default'}`}
+      style={{ backgroundColor: bg, color: text }}
+    >
+      {name}
+    </button>
+  );
+}
+
+const isLeader = true; // TODO: from auth
+
+export default function MinuteDetailPage() {
+  const { minuteId } = useParams<{ minuteId: string }>();
+  const [tab, setTab] = useState<TabType>('요약');
+  const [editing, setEditing] = useState(false);
+  const { setEditSlot } = useHeaderSlotStore();
+
+  const minute = MINUTE_DETAILS[minuteId];
+
+  const initSpeakers = minute
+    ? [...new Set(minute.script.map((e) => e.speaker))].sort((a, b) => a - b)
+    : [];
+
+  const [titleEdit, setTitleEdit] = useState(minute?.title ?? '');
+  const [hashTagsEdit, setHashTagsEdit] = useState<string[]>(minute?.hashTags ?? []);
+  const [hashTagInput, setHashTagInput] = useState('');
+  const [contentEdit, setContentEdit] = useState<string>(
+    [minute?.summary ?? '', ...(minute?.keyPoints ?? [])].filter(Boolean).join('\n\n')
+  );
+  const [scriptEdit, setScriptEdit] = useState<ScriptEntry[]>(minute?.script ?? []);
+  const [speakersEdit, setSpeakersEdit] = useState<number[]>(initSpeakers);
+  const [speakerNames, setSpeakerNames] = useState<Record<number, string>>(() =>
+    Object.fromEntries(initSpeakers.map((n) => [n, `화자${n}`]))
+  );
+  const [speakerSelectorEntry, setSpeakerSelectorEntry] = useState<number | null>(null);
+
+  function rename(speaker: number, name: string) {
+    setSpeakerNames((prev) => ({ ...prev, [speaker]: name }));
+  }
+
+  function addSpeaker() {
+    const next = speakersEdit.length > 0 ? Math.max(...speakersEdit) + 1 : 1;
+    setSpeakersEdit((prev) => [...prev, next]);
+    setSpeakerNames((prev) => ({ ...prev, [next]: `화자${next}` }));
+  }
+
+  function deleteSpeaker(speaker: number) {
+    setSpeakersEdit((prev) => prev.filter((n) => n !== speaker));
+    setSpeakerNames((prev) => { const next = { ...prev }; delete next[speaker]; return next; });
+  }
+
+  function addHashTag(raw: string) {
+    const tag = raw.replace(/^#+/, '').trim();
+    if (tag) setHashTagsEdit((prev) => prev.includes(tag) ? prev : [...prev, tag]);
+    setHashTagInput('');
+  }
+
+  function cancelEdit() {
+    setTitleEdit(minute?.title ?? '');
+    setHashTagsEdit(minute?.hashTags ?? []);
+    setHashTagInput('');
+    setContentEdit([minute?.summary ?? '', ...(minute?.keyPoints ?? [])].filter(Boolean).join('\n\n'));
+    setScriptEdit(minute?.script ?? []);
+    setSpeakersEdit(initSpeakers);
+    setSpeakerNames(Object.fromEntries(initSpeakers.map((n) => [n, `화자${n}`])));
+    setEditing(false);
+  }
+
+  useEffect(() => {
+    if (!isLeader) return;
+    setEditSlot({
+      editing,
+      onEdit: () => setEditing(true),
+      onSave: () => setEditing(false),
+      onCancel: cancelEdit,
+    });
+    return () => setEditSlot(null);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editing]);
+
+  if (!minute) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20">
+        <p className="text-[14px] text-zinc-400">회의록을 찾을 수 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col min-h-full" onClick={() => setSpeakerSelectorEntry(null)}>
+      {/* 제목 · 날짜 */}
+      <div className="pt-5 pb-4">
+        {editing ? (
+          <input
+            value={titleEdit}
+            onChange={(e) => setTitleEdit(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            className="text-[17px] font-bold text-zinc-900 leading-snug w-full border border-zinc-300 rounded-lg px-3 py-1.5 outline-none focus:border-[#3B3EFF] mb-3"
+          />
+        ) : (
+          <h1 className="text-[17px] font-bold text-zinc-900 leading-snug mb-3">{titleEdit}</h1>
+        )}
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-1.5">
+            <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth={2}>
+              <rect x="3" y="4" width="18" height="18" rx="2" strokeLinecap="round" strokeLinejoin="round" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M16 2v4M8 2v4M3 10h18" />
+            </svg>
+            <span className="text-[12px] text-zinc-400">{minute.date}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth={2}>
+              <circle cx="12" cy="12" r="9" strokeLinecap="round" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 7v5l3 2" />
+            </svg>
+            <span className="text-[12px] text-zinc-400">{minute.duration}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 탭바 */}
+      <div className="flex border-t border-b border-zinc-200 -mx-4 sticky top-0 z-10 bg-white">
+        {(['요약', '스크립트', '정보'] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`flex-1 flex justify-center text-[13px] font-medium transition-colors ${tab === t ? 'text-zinc-900' : 'text-zinc-400'}`}
+          >
+            <span className={`inline-block py-2.5 -mb-px ${tab === t ? 'border-b-2 border-zinc-900' : ''}`}>
+              {t}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* 요약 */}
+      {tab === '요약' && (
+        <div className="flex-1 -mx-4 -mb-5 bg-[#EBEBFF] px-4 pt-4 pb-8 flex flex-col gap-3">
+          {/* 박스 1: 해시태그 */}
+          <div className="bg-white rounded-xl px-4 py-3">
+            {editing ? (
+              <div className="flex flex-wrap gap-1.5">
+                {hashTagsEdit.map((tag) => (
+                  <span key={tag} className="inline-flex items-center gap-1 text-[12px] font-semibold text-white bg-[#3B3EFF] pl-2.5 pr-1.5 py-0.5 rounded-full">
+                    #{tag}
+                    <button
+                      onClick={() => setHashTagsEdit((prev) => prev.filter((t) => t !== tag))}
+                      className="w-3.5 h-3.5 rounded-full bg-white/30 flex items-center justify-center shrink-0"
+                    >
+                      <svg width="8" height="8" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round">
+                        <path d="M2 2l6 6M8 2L2 8" />
+                      </svg>
+                    </button>
+                  </span>
+                ))}
+                <input
+                  value={hashTagInput}
+                  onChange={(e) => setHashTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if ((e.key === 'Enter' || e.key === ' ') && hashTagInput.trim()) {
+                      e.preventDefault();
+                      addHashTag(hashTagInput);
+                    }
+                    if (e.key === 'Backspace' && !hashTagInput && hashTagsEdit.length > 0) {
+                      setHashTagsEdit((prev) => prev.slice(0, -1));
+                    }
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                  placeholder={hashTagsEdit.length === 0 ? '#태그 입력 후 Enter' : ''}
+                  className="text-[12px] text-zinc-700 outline-none min-w-[100px] flex-1 placeholder:text-zinc-300"
+                />
+              </div>
+            ) : (
+              <div className="flex flex-wrap gap-1.5">
+                {hashTagsEdit.map((tag) => (
+                  <span key={tag} className="text-[12px] font-semibold text-white bg-[#3B3EFF] px-2.5 py-0.5 rounded-full">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 박스 2: 내용 */}
+          <div className="bg-white rounded-xl p-4">
+            {editing ? (
+              <textarea
+                value={contentEdit}
+                onChange={(e) => setContentEdit(e.target.value)}
+                ref={(el) => {
+                  if (el) { el.style.height = 'auto'; el.style.height = el.scrollHeight + 'px'; }
+                }}
+                onClick={(e) => e.stopPropagation()}
+                rows={6}
+                className="w-full text-[14px] text-zinc-700 leading-relaxed border border-zinc-200 rounded-lg px-3 py-2 outline-none focus:border-[#3B3EFF] resize-none"
+              />
+            ) : (
+              <div>
+                {contentEdit.split('\n').map((line, i) => (
+                  <p key={i} className={`text-[14px] text-zinc-700 leading-relaxed ${line === '' ? 'mt-2' : ''}`}>{line}</p>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 스크립트 */}
+      {tab === '스크립트' && (
+        <div className="flex-1 -mx-4 -mb-5 bg-[#EBEBFF] px-4 pt-4 pb-8">
+          <div className="bg-white rounded-xl p-4 mb-3">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-[13px] font-medium text-zinc-500">참여한 사람</p>
+              <p className="text-[11px] text-zinc-400">눌러서 이름 변경</p>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {speakersEdit.map((n) => (
+                <div key={n} className="relative inline-flex">
+                  <EditableSpeakerBadge
+                    index={n}
+                    name={speakerNames[n] ?? `화자${n}`}
+                    editable={true}
+                    onRename={(name) => rename(n, name)}
+                  />
+                  {editing && (
+                    <button
+                      onClick={(e) => { e.stopPropagation(); deleteSpeaker(n); }}
+                      className="absolute -top-0.5 -right-0.5 w-3 h-3 bg-zinc-400 text-white rounded-full flex items-center justify-center"
+                    >
+                      <svg width="6" height="6" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+                        <path d="M2 2l6 6M8 2L2 8" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              ))}
+              {editing && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); addSpeaker(); }}
+                  className="text-[11px] font-semibold px-2.5 py-0.5 rounded-full border border-zinc-300 text-zinc-500"
+                >
+                  +추가
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl overflow-visible">
+            {scriptEdit.map((entry, i) => (
+              <div
+                key={i}
+                className={`flex items-start gap-2 px-4 py-3 ${i < scriptEdit.length - 1 ? 'border-b border-zinc-50' : ''}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span className="text-[11px] text-zinc-300 font-mono mt-0.5 shrink-0 w-9">{entry.time}</span>
+                <div className="w-[50px] shrink-0 relative">
+                  {editing ? (
+                    <>
+                      <button
+                        onClick={() => setSpeakerSelectorEntry(speakerSelectorEntry === i ? null : i)}
+                        className="text-[11px] font-semibold px-2 py-0.5 rounded-full break-all"
+                        style={{ backgroundColor: getSpeakerColor(entry.speaker).bg, color: getSpeakerColor(entry.speaker).text }}
+                      >
+                        {speakerNames[entry.speaker] ?? `화자${entry.speaker}`}
+                      </button>
+                      {speakerSelectorEntry === i && (
+                        <div className="absolute top-full left-0 z-30 mt-1 bg-white rounded-xl shadow-lg border border-zinc-100 min-w-[96px] overflow-hidden">
+                          {speakersEdit.map((n) => (
+                            <button
+                              key={n}
+                              onClick={() => {
+                                const next = [...scriptEdit];
+                                next[i] = { ...next[i], speaker: n };
+                                setScriptEdit(next);
+                                setSpeakerSelectorEntry(null);
+                              }}
+                              className="flex items-center gap-2 px-3 py-2 w-full text-left hover:bg-zinc-50"
+                            >
+                              <span
+                                className="w-2 h-2 rounded-full shrink-0"
+                                style={{ backgroundColor: getSpeakerColor(n).bg }}
+                              />
+                              <span className="text-[12px] text-zinc-700">{speakerNames[n] ?? `화자${n}`}</span>
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <SpeakerBadge index={entry.speaker} name={speakerNames[entry.speaker] ?? `화자${entry.speaker}`} wrap />
+                  )}
+                </div>
+                {editing ? (
+                  <textarea
+                    value={entry.text}
+                    ref={(el) => {
+                      if (el) { el.style.height = 'auto'; el.style.height = el.scrollHeight + 'px'; }
+                    }}
+                    onChange={(e) => {
+                      const next = [...scriptEdit];
+                      next[i] = { ...next[i], text: e.target.value };
+                      setScriptEdit(next);
+                      e.currentTarget.style.height = 'auto';
+                      e.currentTarget.style.height = e.currentTarget.scrollHeight + 'px';
+                    }}
+                    rows={1}
+                    className="text-[13px] text-zinc-700 flex-1 border border-zinc-200 rounded-lg px-2 py-1 outline-none focus:border-[#3B3EFF] resize-none overflow-hidden"
+                    style={{ minHeight: '28px' }}
+                  />
+                ) : (
+                  <p className="text-[13px] text-zinc-700 leading-relaxed flex-1">{entry.text}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 정보 */}
+      {tab === '정보' && (
+        <div className="flex-1 -mx-4 -mb-5 bg-[#EBEBFF] px-4 pt-4 pb-8">
+          <div className="bg-white rounded-xl overflow-hidden">
+            {[
+              { label: '생성자', value: minute.info.creator },
+              { label: '생성일시', value: minute.info.createdAt },
+              { label: '음성파일', value: minute.info.audioFile },
+              { label: '파일 길이', value: minute.info.fileLength },
+              { label: '파일 크기', value: minute.info.fileSize },
+            ].map(({ label, value }, i, arr) => (
+              <div key={label} className={`flex items-center justify-between px-4 py-3.5 ${i < arr.length - 1 ? 'border-b border-zinc-50' : ''}`}>
+                <span className="text-[13px] text-zinc-400">{label}</span>
+                <span className="text-[13px] font-medium text-zinc-800">{value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/[id]/minutes/_data.ts
+++ b/src/app/[id]/minutes/_data.ts
@@ -1,0 +1,127 @@
+export interface MinuteTag {
+  label: string;
+  className: string;
+}
+
+export interface Minute {
+  id: string;
+  title: string;
+  tags: MinuteTag[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+function tag(label: string): MinuteTag {
+  return { label, className: 'bg-zinc-100 text-zinc-500' };
+}
+
+export interface ScriptEntry {
+  time: string;
+  speaker: number;
+  text: string;
+}
+
+export interface MinuteDetail {
+  id: string;
+  title: string;
+  date: string;
+  duration: string;
+  hashTags: string[];
+  summary: string;
+  keyPoints: string[];
+  script: ScriptEntry[];
+  info: {
+    creator: string;
+    createdAt: string;
+    audioFile: string;
+    fileLength: string;
+    fileSize: string;
+  };
+}
+
+export const MINUTE_DETAILS: Record<string, MinuteDetail> = {
+  '1': {
+    id: '1',
+    title: '사랑의 기술 독서토론 — 사랑은 감정인가 능력인가',
+    date: '2026.04.14',
+    duration: '1시간 14분',
+    hashTags: ['자기수용', '관계'],
+    summary: '에리히 프롬이 말하는 사랑을 \'빠지는 것\'이 아닌 \'실천하는 능력\'으로 보는 관점을 중심으로 토론이 이어졌습니다.\n\n참여자들은 현대 사회에서 사랑이 소비재처럼 다뤄지고 있다는 프롬의 비판에 공감하면서도, 능동적 사랑을 실천하는 것이 현실에서 얼마나 어려운지에 대해 솔직한 이야기를 나눴습니다.',
+    keyPoints: [
+      '사랑을 기술로 본다는 것이 처음엔 낯설었지만 읽을수록 설득력 있다는 의견 다수',
+      '자기 자신을 사랑하지 못하면 타인도 사랑할 수 없다는 명제에 대한 찬반 토론',
+      '형제애, 모성애, 에로스적 사랑의 구분이 실생활에서 어떻게 작동하는지 경험 공유',
+      '집중, 인내, 훈련 없이는 사랑도 깊어질 수 없다는 프롬의 주장에 대한 논의',
+      '다음 책으로 알랭 드 보통의 낭만적 연애와 그 후의 일상 제안 — 다수 동의',
+    ],
+    script: [
+      { time: '00:00', speaker: 1, text: '자 시작할게요. 사랑의 기술 다들 읽어오셨죠? 첫인상이 어땠어요?' },
+      { time: '00:08', speaker: 2, text: '제목 보고 연애 조언서인 줄 알았는데 완전 달랐어요. 철학책에 가깝더라고요.' },
+      { time: '00:40', speaker: 3, text: '저는 첫 챕터에서 충격받았어요. 어떻게 사랑받을까의 문제로만 접근한다는 부분이요.' },
+      { time: '01:12', speaker: 4, text: '사랑받기 위해 매력적으로 보이려는 것, 그게 기본 태도였던 것 같아요.' },
+      { time: '02:05', speaker: 1, text: '맞아요. 프롬은 그걸 뒤집어서 사랑은 능력이고 기술이라고 하잖아요.' },
+      { time: '03:20', speaker: 2, text: '근데 그 말이 처음엔 너무 차갑게 느껴졌어요. 사랑이 감정이 아니라 노력이라니.' },
+      { time: '04:15', speaker: 3, text: '저도 그랬는데 읽다 보니까 오히려 더 진지하게 대하게 되는 것 같더라고요.' },
+      { time: '05:30', speaker: 4, text: '자기 자신을 사랑해야 타인도 사랑할 수 있다는 부분이 제일 와닿았어요.' },
+    ],
+    info: {
+      creator: '김리더',
+      createdAt: '2026.04.14 오후 12:34',
+      audioFile: '6월_정기모임.mp4',
+      fileLength: '1시간 5분 35초',
+      fileSize: '36.7MB',
+    },
+  },
+};
+
+export const MINUTES: Minute[] = [
+  {
+    id: '1',
+    title: '한강, 채식주의자 독서인증!',
+    tags: [tag('해리포터'), tag('소설'), tag('독서')],
+    createdAt: '2026-05-09',
+    updatedAt: '2026-05-09',
+  },
+  {
+    id: '2',
+    title: '한강, 채식주의자 독서인증!',
+    tags: [tag('해리포터'), tag('소설'), tag('독서')],
+    createdAt: '2026-05-08',
+    updatedAt: '2026-05-08',
+  },
+  {
+    id: '3',
+    title: '기시미 이치로, 삶을 변화시키는 용기!',
+    tags: [tag('미움 받을 용기'), tag('비소설'), tag('독서')],
+    createdAt: '2026-04-20',
+    updatedAt: '2026-04-21',
+  },
+  {
+    id: '4',
+    title: '채사장, 현대 사회를 이해하는 키!',
+    tags: [tag('지적 대화를 위한 넓고 얕은 지식'), tag('비소설'), tag('독서')],
+    createdAt: '2026-04-16',
+    updatedAt: '2026-04-16',
+  },
+  {
+    id: '5',
+    title: '톨스토이, 인생에 대한 깊은 성찰!',
+    tags: [tag('안나 카레니나'), tag('소설'), tag('독서')],
+    createdAt: '2026-04-12',
+    updatedAt: '2026-04-13',
+  },
+  {
+    id: '6',
+    title: '조지 오웰, 전체주의에 대한 경고!',
+    tags: [tag('1984'), tag('소설'), tag('독서')],
+    createdAt: '2026-04-08',
+    updatedAt: '2026-04-09',
+  },
+  {
+    id: '7',
+    title: '스티븐 코비, 7가지 습관!',
+    tags: [tag('자기발상'), tag('비소설'), tag('독서')],
+    createdAt: '2026-04-05',
+    updatedAt: '2026-04-05',
+  },
+];

--- a/src/app/[id]/minutes/create/page.tsx
+++ b/src/app/[id]/minutes/create/page.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
+
+interface AudioFile {
+  file: File;
+  duration: string;
+}
+
+function formatSize(bytes: number) {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function readDuration(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const audio = new Audio();
+    const url = URL.createObjectURL(file);
+    audio.onloadedmetadata = () => {
+      URL.revokeObjectURL(url);
+      const total = Math.floor(audio.duration);
+      const h = Math.floor(total / 3600);
+      const m = Math.floor((total % 3600) / 60);
+      resolve(h > 0 ? `${h}시간 ${m}분` : `${m}분`);
+    };
+    audio.onerror = () => { URL.revokeObjectURL(url); resolve(''); };
+    audio.src = url;
+  });
+}
+
+const STEPS = ['파일 업로드', '음성 → 텍스트 변환', '회의록 요약 생성 중', '저장'] as const;
+
+function StepIcon({ status }: { status: 'done' | 'active' | 'waiting' }) {
+  if (status === 'done') {
+    return (
+      <div className="w-6 h-6 rounded-full bg-[#3B3EFF] flex items-center justify-center shrink-0">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.8}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+    );
+  }
+  if (status === 'active') {
+    return (
+      <div className="w-6 h-6 rounded-full bg-[#EBEBFF] flex items-center justify-center shrink-0 animate-spin" style={{ animationDuration: '1.2s' }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#3B3EFF" strokeWidth={2.2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M20 9A8 8 0 0 0 5.64 5.64M4 15a8 8 0 0 0 14.36 3.36" />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="w-6 h-6 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth={2}>
+        <circle cx="12" cy="12" r="9" />
+        <path strokeLinecap="round" d="M12 7v5l3 2" />
+      </svg>
+    </div>
+  );
+}
+
+function GeneratingView({ files, onCancel }: { files: AudioFile[]; onCancel: () => void }) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [dots, setDots] = useState('');
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setCurrentStep(1), 800);
+    const t2 = setTimeout(() => setCurrentStep(2), 2200);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setDots((d) => (d.length >= 3 ? '' : d + '·'));
+    }, 400);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-[#F7F6FF] px-4 pt-6 pb-8 flex flex-col items-center">
+      {/* 스피너 */}
+      <div className="relative w-20 h-20 flex items-center justify-center mb-6 mt-4">
+        <svg className="absolute inset-0 w-full h-full animate-spin" style={{ animationDuration: '2s' }} viewBox="0 0 80 80">
+          <circle cx="40" cy="40" r="36" fill="none" stroke="#DDD9FF" strokeWidth="3.5" />
+          <circle cx="40" cy="40" r="36" fill="none" stroke="#3B3EFF" strokeWidth="3.5"
+            strokeDasharray="58 169" strokeLinecap="round" />
+        </svg>
+        <div className="w-14 h-14 rounded-full bg-[#E8E5FF] flex items-center justify-center">
+          <svg width="36" height="36" viewBox="0 0 24 24" fill="#3B3EFF">
+            <path d="M12 2l1.09 3.26L16.36 6.5l-3.27 1.24L12 11l-1.09-3.26L7.64 6.5l3.27-1.24L12 2z" />
+            <path d="M18.5 10l.72 2.16L21.5 13l-2.28.84L18.5 16l-.72-2.16L15.5 13l2.28-.84L18.5 10z" />
+            <path d="M6 14l.54 1.62L8 16.5l-1.46.88L6 19l-.54-1.62L4 16.5l1.46-.88L6 14z" />
+          </svg>
+        </div>
+      </div>
+
+      <p className="text-[18px] font-bold text-zinc-800 mb-8">AI가 요약하고 있어요</p>
+
+      {/* 진행 단계 */}
+      <div className="w-full bg-white rounded-2xl overflow-hidden mb-4">
+        {STEPS.map((label, idx) => {
+          const status = idx < currentStep ? 'done' : idx === currentStep ? 'active' : 'waiting';
+          return (
+            <div key={label} className={`flex items-center justify-between px-4 py-3.5 ${idx < STEPS.length - 1 ? 'border-b border-zinc-50' : ''}`}>
+              <div className="flex items-center gap-3">
+                <StepIcon status={status} />
+                <span className={`text-[14px] font-medium ${status === 'waiting' ? 'text-zinc-400' : 'text-zinc-800'}`}>
+                  {label}
+                </span>
+              </div>
+              <span className={`text-[13px] font-medium ${status === 'waiting' ? 'text-zinc-300' : 'text-[#3B3EFF]'}`}>
+                {status === 'done' ? '완료' : status === 'active' ? dots || '·' : '대기 중'}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 업로드된 파일 */}
+      {files.map(({ file, duration }, idx) => (
+        <div key={idx} className="w-full bg-white rounded-2xl px-4 py-3.5 flex items-center gap-3 mb-4">
+          <div className="w-9 h-9 rounded-lg bg-[#EBEBFF] flex items-center justify-center shrink-0">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+            </svg>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-[13px] font-semibold text-zinc-800 truncate">{file.name}</p>
+            <p className="text-[12px] text-zinc-400 mt-0.5">{formatSize(file.size)}{duration ? ` · ${duration}` : ''}</p>
+          </div>
+        </div>
+      ))}
+
+      {/* 취소 버튼 */}
+      <button
+        onClick={onCancel}
+        className="w-full border border-zinc-200 bg-transparent text-[15px] font-medium text-zinc-600 py-3.5 rounded-xl"
+      >
+        취소
+      </button>
+    </div>
+  );
+}
+
+export default function MinutesCreatePage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [files, setFiles] = useState<AudioFile[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function addFiles(incoming: FileList | null) {
+    if (!incoming) return;
+    const arr = Array.from(incoming);
+    const withDurations = await Promise.all(
+      arr.map(async (file) => ({ file, duration: await readDuration(file) }))
+    );
+    setFiles((prev) => [...prev, ...withDurations]);
+  }
+
+  function removeFile(idx: number) {
+    setFiles((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+    addFiles(e.dataTransfer.files);
+  }
+
+  if (generating) {
+    return <GeneratingView files={files} onCancel={() => setGenerating(false)} />;
+  }
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-5">
+      <div className="bg-white rounded-xl p-4">
+        <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">
+          회의록 제목 <span className="text-zinc-300 font-normal">(선택)</span>
+        </label>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="미입력 시 AI가 자동으로 생성합니다"
+          className={INPUT_CLS}
+        />
+      </div>
+
+      <div>
+        <div
+          onClick={() => inputRef.current?.click()}
+          onDrop={handleDrop}
+          onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+          onDragLeave={() => setDragging(false)}
+          className={`border-2 border-dashed rounded-xl bg-white px-6 py-10 flex flex-col items-center gap-3 cursor-pointer transition-colors ${dragging ? 'border-[#3B3EFF] bg-blue-50' : 'border-[#3B3EFF]/50'
+            }`}
+        >
+          <div className="w-14 h-14 rounded-2xl bg-[#EBEBFF] flex items-center justify-center">
+            <svg width="30" height="30" fill="none" viewBox="0 0 24 24">
+              <path d="M12 15V4M12 4L8.5 7.5M12 4L15.5 7.5" stroke="#3B3EFF" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+              <path d="M4 17v1.75C4 19.993 4.895 21 6 21h12c1.105 0 2-1.007 2-2.25V17" stroke="#3B3EFF" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </div>
+          <p className="text-[15px] font-bold text-zinc-800">음성 파일 업로드</p>
+          <p className="text-[13px] text-zinc-400 text-center leading-relaxed">
+            탭하여 파일을 선택하거나 여기로 끌어다 놓으세요
+          </p>
+          <input ref={inputRef} type="file" accept="audio/*" multiple className="hidden"
+            onChange={(e) => addFiles(e.target.files)} />
+        </div>
+
+        {files.length > 0 && (
+          <div className="flex flex-col gap-2 mt-3">
+            {files.map(({ file, duration }, idx) => (
+              <div key={idx} className="relative bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
+                <div className="w-9 h-9 rounded-lg bg-[#EBEBFF] flex items-center justify-center shrink-0">
+                  <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                  </svg>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-[13px] font-semibold text-zinc-800 truncate">{file.name}</p>
+                  <p className="text-[12px] text-zinc-400 mt-0.5">{formatSize(file.size)}{duration ? ` · ${duration}` : ''}</p>
+                </div>
+                <button onClick={() => removeFile(idx)}
+                  className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-zinc-400 text-white rounded-full flex items-center justify-center">
+                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={3}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <button
+        disabled={files.length === 0}
+        onClick={() => setGenerating(true)}
+        className="mx-1 bg-[#3B3EFF] disabled:bg-zinc-300 text-white text-[15px] font-semibold py-3.5 rounded-xl transition-colors"
+      >
+        AI 요약 생성
+      </button>
+    </div>
+  );
+}

--- a/src/app/[id]/minutes/page.tsx
+++ b/src/app/[id]/minutes/page.tsx
@@ -1,102 +1,136 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { useParams, useRouter } from 'next/navigation';
-import api from '@/lib/api';
+import { useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { MINUTES, type Minute } from './_data';
 
-interface Team {
-  teamId: string;
-  teamName: string;
-  teamImg: string;
-  teamIntro: string;
-  teamCategory: string;
-  currentMember: number;
-  maxMembers: number;
-  code: string;
+type SortType = '생성일순' | '이름순' | '최근수정일순';
+
+const isLeader = true; // TODO: from auth
+
+function getGroup(dateStr: string): '지난 7일' | '지난 30일' | '이전' {
+  const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400000);
+  if (diff <= 7) return '지난 7일';
+  if (diff <= 30) return '지난 30일';
+  return '이전';
 }
 
-async function fetchGroup(id: string): Promise<Team> {
-  const { data } = await api.get(`/api/groups/${id}`);
-  return data.data;
+function MicIcon() {
+  return (
+    <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth={1.8}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="23" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="8" y1="23" x2="16" y2="23" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
 }
 
-export default function GroupDetailPage() {
+function KebabIcon() {
+  return (
+    <svg width="18" height="18" fill="currentColor" viewBox="0 0 24 24" className="text-zinc-300">
+      <circle cx="12" cy="5" r="1.5" />
+      <circle cx="12" cy="12" r="1.5" />
+      <circle cx="12" cy="19" r="1.5" />
+    </svg>
+  );
+}
+
+function MinuteCard({ minute, groupId }: { minute: Minute; groupId: string }) {
+  return (
+    <Link href={`/${groupId}/minutes/${minute.id}`}>
+      <div className="bg-white rounded-lg px-4 py-3.5 flex items-center gap-3 active:bg-zinc-50 transition-colors">
+        <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+          <MicIcon />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap gap-1 mb-1.5">
+            {minute.tags.map((t) => (
+              <span key={t.label} className={`text-[11px] font-medium px-1.5 py-0.5 rounded-full ${t.className}`}>
+                {t.label}
+              </span>
+            ))}
+          </div>
+          <p className="text-[14px] font-medium text-zinc-800 truncate">{minute.title}</p>
+        </div>
+        <button onClick={(e) => e.preventDefault()} className="shrink-0 p-1">
+          <KebabIcon />
+        </button>
+      </div>
+    </Link>
+  );
+}
+
+export default function MinutesPage() {
   const { id } = useParams<{ id: string }>();
-  const router = useRouter();
+  const [sort, setSort] = useState<SortType>('생성일순');
 
-  const { data: group, isLoading, isError } = useQuery({
-    queryKey: ['group', id],
-    queryFn: () => fetchGroup(id),
-    enabled: !!id,
+  const sorted = [...MINUTES].sort((a, b) => {
+    if (sort === '이름순') return a.title.localeCompare(b.title, 'ko');
+    if (sort === '최근수정일순') return b.updatedAt.localeCompare(a.updatedAt);
+    return b.createdAt.localeCompare(a.createdAt);
   });
 
-  if (isLoading) {
-    return (
-      <main className="max-w-2xl mx-auto px-4 py-10 space-y-4">
-        <div className="h-8 w-48 bg-zinc-100 rounded animate-pulse" />
-        <div className="h-4 w-24 bg-zinc-100 rounded animate-pulse" />
-        <div className="h-32 bg-zinc-100 rounded-xl animate-pulse" />
-      </main>
-    );
-  }
-
-  if (isError || !group) {
-    return (
-      <main className="max-w-2xl mx-auto px-4 py-10 text-center">
-        <p className="text-zinc-500">모임 정보를 불러오지 못했습니다.</p>
-        <button
-          onClick={() => router.back()}
-          className="mt-4 text-sm text-zinc-400 underline"
-        >
-          돌아가기
-        </button>
-      </main>
-    );
-  }
+  const dateKey = sort === '최근수정일순' ? 'updatedAt' : 'createdAt';
+  const GROUP_LABELS = ['지난 7일', '지난 30일', '이전'] as const;
+  const groups = GROUP_LABELS.map((label) => ({
+    label,
+    items: sorted.filter((m) => getGroup(m[dateKey]) === label),
+  })).filter((g) => g.items.length > 0);
 
   return (
-    <main className="max-w-2xl mx-auto px-4 py-10">
-      <button
-        onClick={() => router.back()}
-        className="mb-6 text-sm text-zinc-400 hover:text-zinc-700"
-      >
-        ← 목록으로
-      </button>
+    <div className="flex flex-col min-h-full">
+      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-28">
+        {/* 정렬 */}
+        <div className="flex items-center justify-center mb-4">
+          {(['생성일순', '이름순', '최근수정일순'] as const).map((s, i) => (
+            <span key={s} className="flex items-center">
+              {i > 0 && <span className="text-zinc-300 text-[13px]">|</span>}
+              <button
+                onClick={() => setSort(s)}
+                className={`text-[13px] px-2 ${sort === s ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}
+              >
+                {s}
+              </button>
+            </span>
+          ))}
+        </div>
 
-      <div className="flex items-center gap-4 mb-6">
-        {group.teamImg ? (
-          <img src={group.teamImg} alt={group.teamName} className="w-16 h-16 rounded-full object-cover" />
+        {/* 목록 */}
+        {sort === '이름순' ? (
+          <div className="flex flex-col gap-3">
+            {sorted.map((m) => <MinuteCard key={m.id} minute={m} groupId={id} />)}
+          </div>
         ) : (
-          <div className="w-16 h-16 rounded-full bg-zinc-200 flex items-center justify-center text-zinc-500 text-xl font-bold">
-            {group.teamName[0]}
-          </div>
+          groups.map(({ label, items }) => (
+            <div key={label} className="mb-5">
+              <p className="text-[12px] font-medium text-zinc-400 mb-2 px-1">{label}</p>
+              <div className="flex flex-col gap-3">
+                {items.map((m) => <MinuteCard key={m.id} minute={m} groupId={id} />)}
+              </div>
+            </div>
+          ))
         )}
-        <div>
-          <h1 className="text-2xl font-bold">{group.teamName}</h1>
-          <p className="text-sm text-zinc-400">{group.teamCategory}</p>
-        </div>
-      </div>
 
-      <div className="border border-zinc-200 rounded-xl p-6 space-y-4">
-        <div>
-          <p className="text-xs text-zinc-400 mb-1">소개</p>
-          <p className="text-sm text-zinc-700 leading-relaxed">{group.teamIntro}</p>
-        </div>
-        <div className="flex gap-6">
-          <div>
-            <p className="text-xs text-zinc-400 mb-1">인원</p>
-            <p className="text-sm font-medium">{group.currentMember} / {group.maxMembers}명</p>
-          </div>
-          <div>
-            <p className="text-xs text-zinc-400 mb-1">초대코드</p>
-            <p className="text-sm font-mono font-medium">{group.code}</p>
-          </div>
-        </div>
-      </div>
+        {MINUTES.length === 0 && (
+          <p className="text-center text-[13px] text-zinc-400 py-10">회의록이 없습니다.</p>
+        )}
 
-      <button className="mt-6 w-full py-3 bg-black text-white rounded-xl text-sm font-medium hover:bg-zinc-800 transition-colors">
-        모임 참가하기
-      </button>
-    </main>
+        {/* FAB */}
+        {isLeader && (
+          <Link
+            href={`/${id}/minutes/create`}
+            className="fixed bottom-6 bg-[#3B3EFF] text-white text-[13px] font-semibold px-4 py-2.5 rounded-full shadow-lg flex items-center gap-1.5"
+            style={{ right: 'max(1rem, calc((100vw - 390px) / 2 + 1rem))' }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+            </svg>
+            새 회의록
+          </Link>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/[id]/notices/[noticeId]/page.tsx
+++ b/src/app/[id]/notices/[noticeId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { NOTICES } from '../page';
+import { NOTICES } from '../_data';
 
 export default function NoticeDetailPage() {
   const { noticeId } = useParams<{ noticeId: string }>();

--- a/src/app/[id]/notices/_data.ts
+++ b/src/app/[id]/notices/_data.ts
@@ -1,0 +1,57 @@
+export interface Notice {
+  id: string;
+  title: string;
+  date: string;
+  author: string;
+  content: string;
+  isPinned: boolean;
+  isRequired: boolean;
+}
+
+export const NOTICES: Notice[] = [
+  {
+    id: '1',
+    title: '환영합니다! 독서모임 안내',
+    date: '2026.02.10',
+    author: '김민준',
+    content: '독서 모임에 오신 것을 환영합니다!\n\n매월 1권의 책을 선정하여 함께 읽고 이야기 나눕니다.\n정기 모임은 매월 두 번째 수요일 오후 7시에 진행됩니다.',
+    isPinned: true,
+    isRequired: true,
+  },
+  {
+    id: '2',
+    title: '회비 운영 공지',
+    date: '2026.02.10',
+    author: '이서연',
+    content: '월 회비는 5,000원이며 매월 첫째 주 모임 시 걷습니다.\n회비는 간식비와 모임 장소 대관료로 사용됩니다.',
+    isPinned: true,
+    isRequired: true,
+  },
+  {
+    id: '3',
+    title: '토론 주제 공유해드립니다',
+    date: '2026.02.10',
+    author: '박지호',
+    content: '이번 달 토론 주제를 공유드립니다.\n\n1. 주인공의 선택에 동의하시나요?\n2. 책에서 가장 인상 깊었던 장면은 무엇인가요?\n3. 작가가 전달하려는 메시지는 무엇이라 생각하시나요?',
+    isPinned: false,
+    isRequired: false,
+  },
+  {
+    id: '4',
+    title: '정기 모임 안내',
+    date: '2026.02.10',
+    author: '김민준',
+    content: '이번 달 정기 모임 일정을 안내드립니다.\n\n일시: 2월 12일(수) 오후 7시\n장소: 강남구 카페 라운지\n\n많은 참여 바랍니다.',
+    isPinned: false,
+    isRequired: true,
+  },
+  {
+    id: '5',
+    title: '이번주 읽기 인증 안내',
+    date: '2026.02.10',
+    author: '최유진',
+    content: '이번 주 읽기 인증을 카카오톡 단체방에 올려주세요.\n\n인증 방법: 읽은 페이지가 보이도록 사진 촬영 후 업로드\n마감: 이번 주 일요일 자정',
+    isPinned: false,
+    isRequired: false,
+  },
+];

--- a/src/app/[id]/notices/page.tsx
+++ b/src/app/[id]/notices/page.tsx
@@ -3,66 +3,9 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { NOTICES, type Notice } from './_data';
 
 type SortType = '최근순' | '제목순';
-
-export interface Notice {
-  id: string;
-  title: string;
-  date: string;
-  author: string;
-  content: string;
-  isPinned: boolean;
-  isRequired: boolean;
-}
-
-export const NOTICES: Notice[] = [
-  {
-    id: '1',
-    title: '환영합니다! 독서모임 안내',
-    date: '2026.02.10',
-    author: '김민준',
-    content: '독서 모임에 오신 것을 환영합니다!\n\n매월 1권의 책을 선정하여 함께 읽고 이야기 나눕니다.\n정기 모임은 매월 두 번째 수요일 오후 7시에 진행됩니다.',
-    isPinned: true,
-    isRequired: true,
-  },
-  {
-    id: '2',
-    title: '회비 운영 공지',
-    date: '2026.02.10',
-    author: '이서연',
-    content: '월 회비는 5,000원이며 매월 첫째 주 모임 시 걷습니다.\n회비는 간식비와 모임 장소 대관료로 사용됩니다.',
-    isPinned: true,
-    isRequired: true,
-  },
-  {
-    id: '3',
-    title: '토론 주제 공유해드립니다',
-    date: '2026.02.10',
-    author: '박지호',
-    content: '이번 달 토론 주제를 공유드립니다.\n\n1. 주인공의 선택에 동의하시나요?\n2. 책에서 가장 인상 깊었던 장면은 무엇인가요?\n3. 작가가 전달하려는 메시지는 무엇이라 생각하시나요?',
-    isPinned: false,
-    isRequired: false,
-  },
-  {
-    id: '4',
-    title: '정기 모임 안내',
-    date: '2026.02.10',
-    author: '김민준',
-    content: '이번 달 정기 모임 일정을 안내드립니다.\n\n일시: 2월 12일(수) 오후 7시\n장소: 강남구 카페 라운지\n\n많은 참여 바랍니다.',
-    isPinned: false,
-    isRequired: true,
-  },
-  {
-    id: '5',
-    title: '이번주 읽기 인증 안내',
-    date: '2026.02.10',
-    author: '최유진',
-    content: '이번 주 읽기 인증을 카카오톡 단체방에 올려주세요.\n\n인증 방법: 읽은 페이지가 보이도록 사진 촬영 후 업로드\n마감: 이번 주 일요일 자정',
-    isPinned: false,
-    isRequired: false,
-  },
-];
 
 function PinIcon() {
   return (

--- a/src/store/headerSlot.ts
+++ b/src/store/headerSlot.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface EditSlot {
+  editing: boolean;
+  onEdit: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+interface HeaderSlotStore {
+  editSlot: EditSlot | null;
+  setEditSlot: (slot: EditSlot | null) => void;
+}
+
+export const useHeaderSlotStore = create<HeaderSlotStore>((set) => ({
+  editSlot: null,
+  setEditSlot: (editSlot) => set({ editSlot }),
+}));


### PR DESCRIPTION
## Summary

- 회의록 목록 페이지: 정렬(생성일순/이름순/최근수정일순), 날짜 그룹, 새 회의록 FAB(모임장 전용)
- 회의록 생성 페이지: 음성 파일 다중 업로드, AI 요약 생성 진행 화면(단계별 애니메이션)
- 회의록 상세 페이지: 요약/스크립트/정보 탭, 화자 이름 클릭 수정
- 모임장 편집 모드: 헤더 연필 아이콘 → 제목·요약·해시태그·스크립트 수정, 화자 추가/삭제/재배정
- `headerSlot` Zustand 스토어로 GroupHeader ↔ 상세 페이지 편집 상태 연동
- GroupNav: `/minutes/` 등 상세 페이지 진입 시 탭바 자동 숨김
- 공지 데이터 `_data.ts` 분리(빌드 오류 수정)

## Test plan

- [ ] 회의록 목록 — 정렬 버튼, 카드 클릭 시 상세 이동, FAB(모임장만 노출)
- [ ] 회의록 생성 — 파일 업로드, AI 요약 생성 중 화면, 취소
- [ ] 상세 요약 탭 — 해시태그 추가/삭제, 내용 텍스트 뷰/편집
- [ ] 상세 스크립트 탭 — 화자 이름 변경, 화자 추가/삭제, 스크립트 내 화자 재배정, 텍스트 수정
- [ ] 편집 저장/취소 — 저장 시 내용 유지, 취소 시 원래대로 복구
- [ ] 헤더 높이 — 편집 모드 진입/종료 시 헤더 크기 고정 확인
- [ ] GroupNav — 상세 페이지 진입 시 탭바 숨김 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)