### PR TITLE
feat: 공지 작성 페이지 UI 개선

### DIFF
--- a/src/app/[id]/_components/GroupHeader.tsx
+++ b/src/app/[id]/_components/GroupHeader.tsx
@@ -10,7 +10,7 @@ export default function GroupHeader() {
   const pathname = usePathname();
   const params = useParams();
   const id = params?.id as string;
-  const { editSlot } = useHeaderSlotStore();
+  const { editSlot, pageHeader } = useHeaderSlotStore();
 
   const { data: teamName } = useQuery({
     queryKey: ['groupName', id],
@@ -38,7 +38,9 @@ export default function GroupHeader() {
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <span className="text-[17px] font-bold tracking-tight">{teamName || '모임명'}</span>
+        <span className="text-[17px] font-bold tracking-tight">
+          {pageHeader ? pageHeader.title : (teamName || '모임명')}
+        </span>
       </div>
       {editSlot ? (
         editSlot.editing ? (
@@ -63,6 +65,8 @@ export default function GroupHeader() {
             </svg>
           </button>
         )
+      ) : pageHeader?.hideHamburger ? (
+        <div className="w-7" />
       ) : (
         <button className="p-1 text-zinc-700">
           <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>

--- a/src/app/[id]/notices/new/page.tsx
+++ b/src/app/[id]/notices/new/page.tsx
@@ -1,22 +1,51 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
+const SECTION_LABEL = 'text-[13px] font-semibold text-zinc-600 mb-2 block';
+
+function CheckToggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors shrink-0 ${
+        checked ? 'bg-[#3B3EFF] border-[#3B3EFF]' : 'border-zinc-300 bg-white'
+      }`}
+    >
+      {checked && (
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={3}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      )}
+    </button>
+  );
+}
 
 export default function CreateNoticePage() {
   const router = useRouter();
   const params = useParams();
   const id = params?.id as string;
   const queryClient = useQueryClient();
+  const { setPageHeader } = useHeaderSlotStore();
 
   const [formData, setFormData] = useState({
     notiTitle: '',
     notiContent: '',
     notiFix: 'N',
+    notiRequired: 'N',
     teamId: id,
   });
+
+  useEffect(() => {
+    setPageHeader({ title: '공지 작성하기', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
 
   const createNoticeMutation = useMutation({
     mutationFn: async (data: typeof formData) => {
@@ -25,83 +54,84 @@ export default function CreateNoticePage() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['notices', id] });
-      if (data && data.data && data.data.notiId) {
+      if (data?.data?.notiId) {
         router.push(`/${id}/notices/${data.data.notiId}`);
       } else {
         router.push(`/${id}/notices`);
       }
     },
     onError: (error: any) => {
-      const msg = error?.response?.data?.message || '공지 등록에 실패했습니다. (모임장만 등록 가능할 수 있습니다.)';
-      alert(msg);
-    }
+      alert(error?.response?.data?.message || '공지 등록에 실패했습니다.');
+    },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    createNoticeMutation.mutate(formData);
-  };
+  const isDisabled = createNoticeMutation.isPending || !formData.notiTitle.trim() || !formData.notiContent.trim();
 
   return (
-    <div className="pt-2 px-1">
-      <div className="flex items-center justify-between pb-4 mb-4 border-b border-zinc-100">
-        <h1 className="text-[17px] font-bold text-zinc-900">새 공지사항 작성</h1>
-      </div>
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-5">
 
-      <form onSubmit={handleSubmit} className="space-y-5">
-        <div className="space-y-1.5">
-          <label className="text-[13px] font-semibold text-zinc-800">제목</label>
+      {/* 제목 + 내용 */}
+      <div className="bg-white rounded-xl p-4 flex flex-col gap-4">
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">제목</label>
           <input
             type="text"
             required
             placeholder="공지사항 제목을 입력하세요"
-            className="w-full h-12 px-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors placeholder:text-zinc-400"
+            className={INPUT_CLS}
             value={formData.notiTitle}
             onChange={(e) => setFormData({ ...formData, notiTitle: e.target.value })}
           />
         </div>
-
-        <div className="space-y-1.5">
-          <label className="text-[13px] font-semibold text-zinc-800">내용</label>
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">내용</label>
           <textarea
             required
             placeholder="공지사항 내용을 상세히 작성해 주세요."
-            className="w-full h-64 p-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors resize-none placeholder:text-zinc-400"
+            rows={8}
+            className={`${INPUT_CLS} resize-none`}
             value={formData.notiContent}
             onChange={(e) => setFormData({ ...formData, notiContent: e.target.value })}
           />
         </div>
+      </div>
 
-        <div className="flex items-center gap-2 pt-2">
-          <button
-            type="button"
-            onClick={() => setFormData({ ...formData, notiFix: formData.notiFix === 'Y' ? 'N' : 'Y' })}
-            className="flex items-center justify-center w-5 h-5 rounded border border-zinc-300 bg-white"
-          >
-            {formData.notiFix === 'Y' && (
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#3B3EFF" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            )}
-          </button>
-          <span className="text-[13px] font-medium text-zinc-700 cursor-pointer select-none"
-                onClick={() => setFormData({ ...formData, notiFix: formData.notiFix === 'Y' ? 'N' : 'Y' })}>
-            상단에 고정하고 필독 배지 달기
-          </span>
+      {/* 옵션 */}
+      <div className="px-1">
+        <label className={SECTION_LABEL}>옵션</label>
+        <div className="bg-white rounded-xl divide-y divide-zinc-100">
+          <div className="flex items-center justify-between px-4 py-3.5">
+            <p className="text-[14px] font-medium text-zinc-800">필독</p>
+            <CheckToggle
+              checked={formData.notiRequired === 'Y'}
+              onChange={() => setFormData({ ...formData, notiRequired: formData.notiRequired === 'Y' ? 'N' : 'Y' })}
+            />
+          </div>
+          <div className="flex items-center justify-between px-4 py-3.5">
+            <p className="text-[14px] font-medium text-zinc-800">상단에 고정하기</p>
+            <CheckToggle
+              checked={formData.notiFix === 'Y'}
+              onChange={() => setFormData({ ...formData, notiFix: formData.notiFix === 'Y' ? 'N' : 'Y' })}
+            />
+          </div>
         </div>
+      </div>
 
-        <button
-          type="submit"
-          disabled={createNoticeMutation.isPending || !formData.notiTitle.trim() || !formData.notiContent.trim()}
-          className="w-full h-[52px] mt-6 bg-black text-white rounded-xl text-[15px] font-bold disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors flex items-center justify-center"
-        >
-          {createNoticeMutation.isPending ? (
-            <div className="w-5 h-5 border-2 border-zinc-500 border-t-white rounded-full animate-spin" />
-          ) : (
-            '공지 등록하기'
-          )}
-        </button>
-      </form>
+      {/* 등록 버튼 */}
+      <button
+        type="button"
+        onClick={() => !isDisabled && createNoticeMutation.mutate(formData)}
+        disabled={isDisabled}
+        className={`mx-1 text-[15px] font-semibold py-3.5 rounded-xl transition-colors flex items-center justify-center ${
+          isDisabled ? 'bg-zinc-300 text-white' : 'bg-[#3B3EFF] text-white'
+        }`}
+      >
+        {createNoticeMutation.isPending ? (
+          <div className="w-5 h-5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+        ) : (
+          '공지 등록'
+        )}
+      </button>
     </div>
   );
 }

--- a/src/store/headerSlot.ts
+++ b/src/store/headerSlot.ts
@@ -7,12 +7,21 @@ interface EditSlot {
   onCancel: () => void;
 }
 
+interface PageHeader {
+  title: string;
+  hideHamburger: boolean;
+}
+
 interface HeaderSlotStore {
   editSlot: EditSlot | null;
   setEditSlot: (slot: EditSlot | null) => void;
+  pageHeader: PageHeader | null;
+  setPageHeader: (header: PageHeader | null) => void;
 }
 
 export const useHeaderSlotStore = create<HeaderSlotStore>((set) => ({
   editSlot: null,
   setEditSlot: (editSlot) => set({ editSlot }),
+  pageHeader: null,
+  setPageHeader: (pageHeader) => set({ pageHeader }),
 }));


### PR DESCRIPTION
## Summary
- 레이아웃을 투표/회의록 생성 페이지와 동일하게 개선 (회색 배경 + 흰 카드)
- 필독 / 상단에 고정하기 체크박스 분리
- 헤더 타이틀 '공지 작성하기'로 변경, 햄버거 아이콘 제거
- 버튼 비활성화 시 회색 배경 흰 글자, 활성화 시 파란 배경 흰 글자
- headerSlot 스토어에 pageHeader 기능 추가 (votes/minutes 생성 페이지에서도 활용)

## Test plan
- [ ] 제목/내용 입력 전 버튼 비활성화 확인
- [ ] 필독 / 상단 고정 체크박스 독립 동작 확인
- [ ] 헤더에 '공지 작성하기' 표시 및 페이지 이탈 시 원복 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)