### PR TITLE
feat: home 탭 개선, 그룹 헤더 팝업, 모임 정보 페이지, 멤버 프로필 편집/강퇴

### DIFF
--- a/src/app/[id]/_components/GroupHeader.tsx
+++ b/src/app/[id]/_components/GroupHeader.tsx
@@ -1,9 +1,18 @@
 'use client';
 
+import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter, usePathname, useParams } from 'next/navigation';
 import { useHeaderSlotStore } from '@/store/headerSlot';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
+
+interface MemberMe {
+  memId: string;
+  memNic: string;
+  memRole: string;
+  memState: string;
+}
 
 export default function GroupHeader() {
   const router = useRouter();
@@ -11,6 +20,8 @@ export default function GroupHeader() {
   const params = useParams();
   const id = params?.id as string;
   const { editSlot, pageHeader } = useHeaderSlotStore();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   const { data: teamName } = useQuery({
     queryKey: ['groupName', id],
@@ -21,59 +32,146 @@ export default function GroupHeader() {
     enabled: !!id,
   });
 
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data;
+    },
+    enabled: !!id,
+  });
+
+  const initial = myMember?.memNic?.[0] ?? '?';
+
+  const leaveMutation = useMutation({
+    mutationFn: () => api.delete(`/api/members/${myMember?.memId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myTeams'] });
+      router.push('/main');
+    },
+  });
+
+  const handleLeave = () => {
+    if (confirm('정말 이 모임을 탈퇴하시겠습니까?')) {
+      leaveMutation.mutate();
+    }
+  };
+
   const segments = pathname.split('/');
-  let backHref = '/main';
-  if (segments.length >= 4) {
-    if (pathname.includes('/events/')) backHref = `/${segments[1]}/events`;
-    else if (pathname.includes('/notices/')) backHref = `/${segments[1]}/notices`;
-    else if (pathname.includes('/votes/')) backHref = `/${segments[1]}/votes`;
-    else if (pathname.includes('/minutes/')) backHref = `/${segments[1]}/minutes`;
-  }
+  const handleBack = () => {
+    if (segments.length >= 4) {
+      if (pathname.includes('/events/')) router.push(`/${segments[1]}/events`);
+      else if (pathname.includes('/notices/')) router.push(`/${segments[1]}/notices`);
+      else if (pathname.includes('/votes/')) router.push(`/${segments[1]}/votes`);
+      else if (pathname.includes('/minutes/')) router.push(`/${segments[1]}/minutes`);
+      else router.back();
+    } else {
+      router.back();
+    }
+  };
 
   return (
-    <header className="flex items-center justify-between px-4 h-[52px] shrink-0 border-b border-zinc-100 bg-white">
-      <div className="flex items-center gap-2">
-        <button onClick={() => router.push(backHref)} className="p-1 text-zinc-500">
-          <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
-        <span className="text-[17px] font-bold tracking-tight">
-          {pageHeader ? pageHeader.title : (teamName || '모임명')}
-        </span>
-      </div>
-      {editSlot ? (
-        editSlot.editing ? (
-          <div className="flex items-center gap-2">
-            <button
-              onClick={editSlot.onCancel}
-              className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1"
-            >
-              취소
-            </button>
-            <button
-              onClick={editSlot.onSave}
-              className="text-[13px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3 py-1"
-            >
-              저장
-            </button>
-          </div>
-        ) : (
-          <button onClick={editSlot.onEdit} className="p-1 text-zinc-600">
-            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 16H9v-3z" />
+    <>
+      <header className="flex items-center justify-between px-4 h-[52px] shrink-0 border-b border-zinc-100 bg-white">
+        <div className="flex items-center gap-2">
+          <button onClick={handleBack} className="p-1 text-zinc-500">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-        )
-      ) : pageHeader?.hideHamburger ? (
-        <div className="w-7" />
-      ) : (
-        <button className="p-1 text-zinc-700">
-          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
+          <span className="text-[17px] font-bold tracking-tight">
+            {pageHeader ? pageHeader.title : (teamName || '모임명')}
+          </span>
+        </div>
+
+        {editSlot ? (
+          editSlot.editing ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={editSlot.onCancel}
+                className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1"
+              >
+                취소
+              </button>
+              <button
+                onClick={editSlot.onSave}
+                className="text-[13px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3 py-1"
+              >
+                저장
+              </button>
+            </div>
+          ) : (
+            <button onClick={editSlot.onEdit} className="p-1 text-zinc-600">
+              <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 13l6.586-6.586a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 16H9v-3z" />
+              </svg>
+            </button>
+          )
+        ) : pageHeader?.hideHamburger ? (
+          <div className="w-7" />
+        ) : (
+          <button onClick={() => setMenuOpen(true)} className="p-1 text-zinc-700">
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        )}
+      </header>
+
+      {menuOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
+          <div className="fixed top-[52px] right-4 z-50 bg-white rounded-xl shadow-xl w-[190px] overflow-hidden border border-zinc-100"
+            style={{ right: 'calc(50% - 195px + 16px)' }}>
+
+            {/* 모임 내 프로필 */}
+            <div className="flex items-center gap-2.5 px-3.5 py-3 border-b border-zinc-100">
+              <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
+                <span className="text-[13px] font-bold text-white">{initial}</span>
+              </div>
+              <p className="text-[13px] font-bold text-zinc-900 truncate">{myMember?.memNic ?? '...'}</p>
+            </div>
+
+            {/* 모임 정보 */}
+            <Link
+              href={`/${id}/info`}
+              onClick={() => setMenuOpen(false)}
+              className="flex items-center gap-2.5 px-4 py-3 border-b border-zinc-100 hover:bg-zinc-50"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              <span className="text-[13px] font-medium text-zinc-800">모임 정보</span>
+            </Link>
+
+            {/* 모임내 프로필 */}
+            {myMember && (
+              <Link
+                href={`/${id}/members/${myMember.memId}`}
+                onClick={() => setMenuOpen(false)}
+                className="flex items-center gap-2.5 px-4 py-3 border-b border-zinc-100 hover:bg-zinc-50"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" /><circle cx="12" cy="7" r="4" />
+                </svg>
+                <span className="text-[13px] font-medium text-zinc-800">모임 프로필</span>
+              </Link>
+            )}
+
+            {/* 모임 탈퇴 */}
+            <button
+              onClick={handleLeave}
+              disabled={leaveMutation.isPending}
+              className="w-full flex items-center gap-2.5 px-4 py-3 hover:bg-zinc-50"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9" />
+              </svg>
+              <span className="text-[13px] font-medium text-red-500">모임 탈퇴</span>
+            </button>
+          </div>
+        </>
       )}
-    </header>
+    </>
   );
 }

--- a/src/app/[id]/_components/GroupNav.tsx
+++ b/src/app/[id]/_components/GroupNav.tsx
@@ -11,7 +11,6 @@ const TABS = [
   { label: '공지', href: 'notices' },
   { label: '미션', href: 'missions' },
   { label: '기록', href: 'minutes' },
-  { label: '소식', href: 'news' },
 ];
 
 export default function GroupNav({ groupId }: { groupId: string }) {
@@ -19,8 +18,11 @@ export default function GroupNav({ groupId }: { groupId: string }) {
 
   const segments = pathname.split('/');
   const isDetailPage =
-    segments.length >= 4 &&
-    (pathname.includes('/events/') || pathname.includes('/notices/') || pathname.includes('/votes/') || pathname.includes('/minutes/'));
+    pathname.endsWith('/info') ||
+    (segments.length >= 4 &&
+      (pathname.includes('/events/') || pathname.includes('/notices/') ||
+       pathname.includes('/votes/') || pathname.includes('/minutes/') ||
+       pathname.includes('/members/')));
   if (isDetailPage) return null;
 
   return (

--- a/src/app/[id]/home/page.tsx
+++ b/src/app/[id]/home/page.tsx
@@ -1,18 +1,16 @@
 'use client';
 
-import { useState } from 'react';
-
 const NEWS_ITEMS = [
-  { id: 1, group: '모임1', dot: '#f97316', content: "이 '새 공지를 작성했'어요", time: '10분 전', badge: null },
-  { id: 2, group: '모임2', dot: '#3b82f6', content: '새 투표가 시작됐어요. 참여해보세요!', time: '1시간 전', badge: { count: '128', label: '24시' } },
-  { id: 3, group: '모임1', dot: '#f97316', content: '이번 주 미션이 업데이트됐어요', time: '2시간 전', badge: null },
-  { id: 4, group: '모임3', dot: '#22c55e', content: '새 일정이 등록됐어요. 확인해보세요.', time: '어제', badge: null },
+  { id: 1, content: '새 공지를 작성했어요', time: '10분 전' },
+  { id: 2, content: '새 투표가 시작됐어요. 참여해보세요!', time: '1시간 전' },
+  { id: 3, content: '이번 주 미션이 업데이트됐어요', time: '2시간 전' },
+  { id: 4, content: '새 일정이 등록됐어요. 확인해보세요.', time: '어제' },
 ];
 
 const RANKING = [
-  { rank: 1, score: 98, emoji: '🥇', isMe: false },
-  { rank: 2, score: 85, emoji: '🥈', isMe: false },
-  { rank: 3, score: 72, emoji: '🥉', isMe: false },
+  { rank: 1, score: 98, emoji: '🥇' },
+  { rank: 2, score: 85, emoji: '🥈' },
+  { rank: 3, score: 72, emoji: '🥉' },
 ];
 
 function CircleProgress({ pct, size = 84, sw = 7, color = '#111827' }: { pct: number; size?: number; sw?: number; color?: string }) {
@@ -51,46 +49,23 @@ function DonutChart({ pct, label, color }: { pct: number; label: string; color: 
 }
 
 export default function GroupHomePage() {
-  const [newsFilter, setNewsFilter] = useState<'전체' | '모임별'>('전체');
-
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pt-4">
       {/* 최근 소식 */}
       <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-[15px] font-bold">최근 소식</h2>
-          <div className="flex gap-1.5">
-            {(['전체', '모임별'] as const).map((f) => (
-              <button key={f} onClick={() => setNewsFilter(f)}
-                className={`text-xs px-3 py-1 rounded-full transition-colors ${newsFilter === f ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-500'
-                  }`}>
-                {f}
-              </button>
-            ))}
-          </div>
-        </div>
+        <h2 className="text-[15px] font-bold mb-3">최근 소식</h2>
         <div className="space-y-2">
           {NEWS_ITEMS.map((item) => (
             <div key={item.id} className="flex items-center gap-3 p-3 rounded-xl bg-zinc-50">
-              <div className="relative shrink-0">
-                <div className="w-10 h-10 rounded-full bg-zinc-200" />
-                <span className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border-2 border-white"
-                  style={{ backgroundColor: item.dot }} />
+              <div className="w-9 h-9 rounded-full bg-[#3B3EFF] shrink-0 flex items-center justify-center">
+                <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="white" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                </svg>
               </div>
               <div className="flex-1 min-w-0">
-                <span className="inline-block text-[11px] font-semibold px-1.5 py-0.5 rounded mb-0.5"
-                  style={{ backgroundColor: item.dot + '22', color: item.dot }}>
-                  {item.group}
-                </span>
-                <p className="text-[13px] text-zinc-800 leading-snug truncate">{item.content}</p>
+                <p className="text-[13px] text-zinc-800 leading-snug">{item.content}</p>
                 <p className="text-[11px] text-zinc-400 mt-0.5">{item.time}</p>
               </div>
-              {item.badge && (
-                <div className="shrink-0 flex flex-col items-end gap-1">
-                  <span className="text-[11px] bg-zinc-800 text-white rounded-full px-2 py-0.5 font-medium">{item.badge.count}</span>
-                  <span className="text-[11px] text-zinc-400">{item.badge.label}</span>
-                </div>
-              )}
             </div>
           ))}
         </div>

--- a/src/app/[id]/info/page.tsx
+++ b/src/app/[id]/info/page.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+import api from '@/lib/api';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+interface Team {
+  teamId: string;
+  teamName: string;
+  teamImg: string;
+  teamInfo: string;
+  teamCategory: string;
+  currentMember: number;
+  maxMembers: number;
+  code: string;
+}
+
+interface MemberMe {
+  memId: string;
+  memNic: string;
+  memRole: string;
+  memState: string;
+}
+
+export default function GroupInfoPage() {
+  const { id } = useParams<{ id: string }>();
+  const { setPageHeader } = useHeaderSlotStore();
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+
+  const [teamName, setTeamName] = useState('');
+  const [teamInfo, setTeamInfo] = useState('');
+  const [teamCategory, setTeamCategory] = useState('');
+  const [maxMembers, setMaxMembers] = useState('');
+  const initialized = useRef(false);
+
+  const { data: group, isLoading } = useQuery<Team>({
+    queryKey: ['group', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/teams/${id}`);
+      return data.data;
+    },
+    enabled: !!id,
+  });
+
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data;
+    },
+    enabled: !!id,
+  });
+
+  if (group && !initialized.current) {
+    setTeamName(group.teamName);
+    setTeamInfo(group.teamInfo ?? '');
+    setTeamCategory(group.teamCategory ?? '');
+    setMaxMembers(String(group.maxMembers));
+    initialized.current = true;
+  }
+
+  const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
+
+  const { mutate: save, isPending } = useMutation({
+    mutationFn: () =>
+      api.put(`/api/teams/${id}`, {
+        teamId: id,
+        teamName,
+        teamInfo,
+        teamCategory,
+        maxMembers: Number(maxMembers),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group', id] });
+      queryClient.invalidateQueries({ queryKey: ['groupName', id] });
+      setEditing(false);
+    },
+  });
+
+  const handleCancel = () => {
+    if (group) {
+      setTeamName(group.teamName);
+      setTeamInfo(group.teamInfo ?? '');
+      setTeamCategory(group.teamCategory ?? '');
+      setMaxMembers(String(group.maxMembers));
+    }
+    setEditing(false);
+  };
+
+  useEffect(() => {
+    setPageHeader({ title: '모임 정보', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
+  if (isLoading) {
+    return (
+      <div className="pt-4 px-2 space-y-3">
+        <div className="h-14 w-full bg-zinc-100 rounded animate-pulse" />
+        <div className="h-32 bg-zinc-100 rounded-xl animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!group) {
+    return <p className="pt-8 text-center text-[13px] text-zinc-400">모임 정보를 불러오지 못했습니다.</p>;
+  }
+
+  return (
+    <div className="pt-4 px-2 space-y-4">
+      {/* 모임 이미지 + 이름 + 버튼 */}
+      <div className="flex items-center gap-4">
+        {group.teamImg ? (
+          <img src={group.teamImg} alt={group.teamName} className="w-14 h-14 rounded-full object-cover shrink-0" />
+        ) : (
+          <div className="w-14 h-14 rounded-full bg-[#C4B5FD] flex items-center justify-center text-white text-xl font-bold shrink-0">
+            {group.teamName[0]}
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-[17px] font-bold text-zinc-900 truncate">{group.teamName}</p>
+          <p className="text-[13px] text-zinc-400">{group.teamCategory}</p>
+        </div>
+        {isLeader && !editing && (
+          <button
+            onClick={() => setEditing(true)}
+            className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1 shrink-0"
+          >
+            수정
+          </button>
+        )}
+        {isLeader && editing && (
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={handleCancel}
+              className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1"
+            >
+              취소
+            </button>
+            <button
+              onClick={() => save()}
+              disabled={isPending}
+              className="text-[13px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3 py-1 disabled:opacity-60"
+            >
+              완료
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-zinc-100" />
+
+      {/* 상세 정보 */}
+      <div>
+        {[
+          { label: '모임 이름', value: teamName, set: setTeamName },
+          { label: '소개', value: teamInfo, set: setTeamInfo },
+        ].map(({ label, value, set }) => (
+          <div key={label} className="flex items-center py-3 gap-4">
+            <span className="text-[13px] text-zinc-400 w-20 shrink-0">{label}</span>
+            {editing ? (
+              <input
+                type="text"
+                value={value}
+                onChange={(e) => set(e.target.value)}
+                className="flex-1 text-[13px] text-zinc-800 border-b border-zinc-300 outline-none py-0.5 bg-transparent focus:border-[#3B3EFF]"
+              />
+            ) : (
+              <span className="text-[13px] text-zinc-800">{value || '-'}</span>
+            )}
+          </div>
+        ))}
+
+        {/* 카테고리 */}
+        <div className="flex items-center py-3 gap-4">
+          <span className="text-[13px] text-zinc-400 w-20 shrink-0">카테고리</span>
+          {editing ? (
+            <select
+              value={teamCategory}
+              onChange={(e) => setTeamCategory(e.target.value)}
+              className="flex-1 text-[13px] text-zinc-800 border-b border-zinc-300 outline-none py-0.5 bg-transparent focus:border-[#3B3EFF]"
+            >
+              {['독서', '스터디', '운동', '프로젝트', '친목', '기타'].map((cat) => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-[13px] text-zinc-800">{teamCategory || '-'}</span>
+          )}
+        </div>
+
+        {/* 최대 인원 */}
+        <div className="flex items-center py-3 gap-4">
+          <span className="text-[13px] text-zinc-400 w-20 shrink-0">최대 인원</span>
+          {editing ? (
+            <div className="flex items-center gap-3 flex-1">
+              <input
+                type="range"
+                min="2"
+                max="15"
+                value={maxMembers}
+                onChange={(e) => setMaxMembers(e.target.value)}
+                className="flex-1 accent-[#3B3EFF]"
+              />
+              <span className="text-[13px] font-semibold text-zinc-800 w-10 text-right shrink-0">
+                {maxMembers}명
+              </span>
+            </div>
+          ) : (
+            <span className="text-[13px] text-zinc-800">{maxMembers}명</span>
+          )}
+        </div>
+
+        <div className="flex items-center py-3 gap-4">
+          <span className="text-[13px] text-zinc-400 w-20 shrink-0">현재 인원</span>
+          <span className="text-[13px] text-zinc-800">{group.currentMember}명</span>
+        </div>
+        <div className="flex items-center py-3 gap-4">
+          <span className="text-[13px] text-zinc-400 w-20 shrink-0">초대코드</span>
+          <span className="text-[13px] text-zinc-800 font-mono">{group.code}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[id]/members/[memberId]/page.tsx
+++ b/src/app/[id]/members/[memberId]/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
@@ -27,13 +28,82 @@ const STATE_DOT: Record<string, string> = {
   R: 'bg-red-500',
 };
 
+function EditModal({
+  member,
+  onClose,
+  onSave,
+  isPending,
+}: {
+  member: MemberResponse;
+  onClose: () => void;
+  onSave: (nick: string) => void;
+  isPending: boolean;
+}) {
+  const [nick, setNick] = useState(member.memNic ?? '');
+  const [bio, setBio] = useState('');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
+      <div className="bg-white rounded-2xl w-full max-w-[320px] p-6 shadow-xl relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 w-7 h-7 rounded-full bg-zinc-100 flex items-center justify-center"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+        <h3 className="text-[16px] font-bold text-zinc-900 text-center mb-5">프로필 수정</h3>
+
+        <div className="flex items-center gap-4 mb-5">
+          <div className="w-16 h-16 rounded-full bg-[#C4B5FD] flex items-center justify-center text-[22px] font-bold text-white shrink-0">
+            {nick[0] || '?'}
+          </div>
+          <button className="flex-1 h-10 border border-zinc-300 rounded-xl text-[13px] font-medium text-zinc-700">
+            이미지 업로드
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3 mb-3">
+          <span className="text-[13px] font-medium text-zinc-600 w-16 shrink-0">닉네임</span>
+          <input
+            value={nick}
+            onChange={(e) => setNick(e.target.value)}
+            className="flex-1 border border-[#3B3EFF] rounded-lg px-3 py-1.5 text-[13px] outline-none"
+          />
+        </div>
+
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-[13px] font-medium text-zinc-600 w-16 shrink-0">한줄 소개</span>
+          <input
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            placeholder="한줄 소개"
+            className="flex-1 border border-zinc-200 rounded-lg px-3 py-1.5 text-[13px] outline-none"
+          />
+        </div>
+
+        <button
+          onClick={() => onSave(nick)}
+          disabled={isPending}
+          className="w-full bg-[#3B3EFF] text-white text-[14px] font-semibold rounded-xl py-2.5 disabled:opacity-60"
+        >
+          완료
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function MemberDetailPage() {
   const { id, memberId } = useParams<{ id: string; memberId: string }>();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [showKickConfirm, setShowKickConfirm] = useState(false);
 
   const { data: myMembership } = useQuery({
-    queryKey: ['members', 'me', id],
+    queryKey: ['memberMe', id],
     queryFn: async () => {
       const { data } = await api.get(`/api/members/me?teamId=${id}`);
       return data.data as MemberResponse;
@@ -52,28 +122,33 @@ export default function MemberDetailPage() {
     enabled: !!memberId,
   });
 
+  const isOwnProfile = member?.memId === myMembership?.memId;
+
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ['members', id] });
     queryClient.invalidateQueries({ queryKey: ['member', memberId] });
+    queryClient.invalidateQueries({ queryKey: ['memberMe', id] });
   };
 
   const approveMutation = useMutation({
     mutationFn: () => api.patch(`/api/members/${memberId}/approve`),
-    onSuccess: () => {
-      invalidate();
-      router.back();
-    },
+    onSuccess: () => { invalidate(); router.back(); },
   });
 
   const rejectMutation = useMutation({
     mutationFn: () => api.patch(`/api/members/${memberId}/reject`),
-    onSuccess: () => {
-      invalidate();
-      router.back();
-    },
+    onSuccess: () => { invalidate(); router.back(); },
   });
 
-  const isPending = approveMutation.isPending || rejectMutation.isPending;
+  const saveMutation = useMutation({
+    mutationFn: (nick: string) => api.patch(`/api/members/${memberId}`, { memNic: nick }),
+    onSuccess: () => { invalidate(); setShowEditModal(false); },
+  });
+
+  const kickMutation = useMutation({
+    mutationFn: () => api.delete(`/api/members/${memberId}`),
+    onSuccess: () => { invalidate(); router.back(); },
+  });
 
   if (isLoading) {
     return <div className="text-center py-20 text-zinc-500 text-sm">불러오는 중...</div>;
@@ -92,23 +167,72 @@ export default function MemberDetailPage() {
 
   return (
     <div className="pt-6 px-1">
-      <div className="flex flex-col items-center pb-8 border-b border-zinc-100">
-        <div className="w-20 h-20 rounded-full bg-zinc-200 flex items-center justify-center text-[24px] font-bold text-zinc-500 mb-4 shadow-sm">
-          {member.memNic ? member.memNic[0] : '?'}
+      {showKickConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
+          <div className="bg-white rounded-2xl w-full max-w-[300px] p-6 shadow-xl">
+            <h3 className="text-[16px] font-bold text-zinc-900 text-center mb-2">멤버 강퇴</h3>
+            <p className="text-[13px] text-zinc-500 text-center mb-6">
+              <span className="font-semibold text-zinc-800">{member.memNic}</span> 님을 모임에서 강퇴하시겠습니까?
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowKickConfirm(false)}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-medium text-zinc-600 border border-zinc-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => kickMutation.mutate()}
+                disabled={kickMutation.isPending}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-semibold text-white bg-red-500 disabled:opacity-60"
+              >
+                강퇴
+              </button>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-2 mb-1">
-          <h1 className="text-[20px] font-bold text-zinc-900">{member.memNic}</h1>
-          {member.memRole === 'L' && (
-            <span className="text-[11px] font-semibold text-white bg-[#3B3EFF] rounded-full px-2 py-0.5">
-              리더
-            </span>
-          )}
+      )}
+
+      {showEditModal && (
+        <EditModal
+          member={member}
+          onClose={() => setShowEditModal(false)}
+          onSave={(nick) => saveMutation.mutate(nick)}
+          isPending={saveMutation.isPending}
+        />
+      )}
+
+      {/* 프로필 상단 */}
+      <div className="flex items-center gap-4 pb-8 border-b border-zinc-100">
+        <div className="w-20 h-20 rounded-full bg-[#C4B5FD] flex items-center justify-center text-[24px] font-bold text-white shrink-0">
+          {member.memNic[0] || '?'}
         </div>
-        <p className="text-[13px] text-zinc-500">
-          {member.memRole === 'L' ? '모임장' : '일반 멤버'}
-        </p>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h1 className="text-[20px] font-bold text-zinc-900 truncate">{member.memNic}</h1>
+            {member.memRole === 'L' && (
+              <span className="text-[11px] font-semibold text-white bg-[#3B3EFF] rounded-full px-2 py-0.5 shrink-0">
+                리더
+              </span>
+            )}
+          </div>
+          <p className="text-[13px] text-zinc-500">
+            {member.memRole === 'L' ? '모임장' : '일반 멤버'}
+          </p>
+        </div>
+
+        {isOwnProfile && (
+          <button
+            onClick={() => setShowEditModal(true)}
+            className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1 shrink-0"
+          >
+            수정
+          </button>
+        )}
       </div>
 
+      {/* 상세 정보 */}
       <div className="py-6 space-y-5">
         <div>
           <p className="text-[12px] font-semibold text-zinc-400 mb-1">가입 신청일</p>
@@ -123,7 +247,7 @@ export default function MemberDetailPage() {
         <div>
           <p className="text-[12px] font-semibold text-zinc-400 mb-1">상태</p>
           <div className="flex items-center gap-2 mt-1">
-            <span className={`flex w-2 h-2 rounded-full ${STATE_DOT[member.memState] ?? 'bg-zinc-400'}`} />
+            <span className={`w-2 h-2 rounded-full ${STATE_DOT[member.memState] ?? 'bg-zinc-400'}`} />
             <span className="text-[14px] font-medium text-zinc-800">
               {STATE_LABELS[member.memState] ?? member.memState}
             </span>
@@ -135,17 +259,28 @@ export default function MemberDetailPage() {
         <div className="flex gap-3 pt-2">
           <button
             onClick={() => rejectMutation.mutate()}
-            disabled={isPending}
-            className="flex-1 py-3 rounded-xl text-[14px] font-semibold border border-zinc-200 text-zinc-600 disabled:opacity-50 active:bg-zinc-50"
+            disabled={approveMutation.isPending || rejectMutation.isPending}
+            className="flex-1 py-3 rounded-xl text-[14px] font-semibold border border-zinc-200 text-zinc-600 disabled:opacity-50"
           >
             거절
           </button>
           <button
             onClick={() => approveMutation.mutate()}
-            disabled={isPending}
-            className="flex-1 py-3 rounded-xl text-[14px] font-semibold bg-[#3B3EFF] text-white disabled:opacity-50 active:opacity-90"
+            disabled={approveMutation.isPending || rejectMutation.isPending}
+            className="flex-1 py-3 rounded-xl text-[14px] font-semibold bg-[#3B3EFF] text-white disabled:opacity-50"
           >
             승인
+          </button>
+        </div>
+      )}
+
+      {isLeader && !isOwnProfile && member.memState === 'A' && (
+        <div className="pt-2">
+          <button
+            onClick={() => setShowKickConfirm(true)}
+            className="w-full py-3 rounded-xl text-[14px] font-semibold text-red-500 border border-red-200"
+          >
+            강퇴
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- home 탭 최근소식 개선 — 필터 제거, 아이콘 파란색
- 그룹 햄버거 팝업 메뉴 — 모임 프로필, 모임 정보, 모임 탈퇴
- `/[id]/info` 모임 정보 페이지 신규 (모임장만 수정 가능)
- 탭바 숨김 조건 추가 — info, members 상세 페이지 진입 시
- 멤버 프로필 수정 팝업 (본인만), 모임장 강퇴 버튼 + 확인 팝업

## Test plan
- [ ] 햄버거 팝업 — 모임 정보/프로필/탈퇴 동작 확인
- [ ] 모임 정보 페이지에서 모임장만 수정 버튼 보이는지 확인
- [ ] 멤버 상세에서 본인만 수정, 모임장만 강퇴 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)