### PR TITLE
feat: 일정 생성/수정 개선 — 장소·시간, 모임장 전용 수정

### DIFF
--- a/src/app/[id]/events/[eventId]/page.tsx
+++ b/src/app/[id]/events/[eventId]/page.tsx
@@ -1,22 +1,60 @@
 'use client';
 
+import { useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 interface EventResponse {
   evtId: number;
   evtTitle: string;
   evtContent: string;
+  evtLocation: string;
   evtStartDt: string;
   evtEndDt: string;
   evtRegDtm: string;
   teamId: string;
 }
 
+interface MemberMe {
+  memRole: string;
+  memState: string;
+}
+
+const DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatDate(dt: string) {
+  const d = new Date(dt);
+  const base = `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${DAY_NAMES[d.getDay()]})`;
+  const time = dt.length > 10 ? ` ${d.getHours().toString().padStart(2, '0')}:${d.getMinutes().toString().padStart(2, '0')}` : '';
+  return base + time;
+}
+
 export default function EventDetailPage() {
-  const { eventId } = useParams<{ eventId: string }>();
+  const { id, eventId } = useParams<{ id: string; eventId: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [editing, setEditing] = useState(false);
+  const [title, setTitle] = useState('');
+  const [location, setLocation] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [content, setContent] = useState('');
+  const initialized = useRef(false);
+
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data;
+    },
+    enabled: !!id,
+  });
+
+  const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
 
   const { data: event, isLoading } = useQuery({
     queryKey: ['event', eventId],
@@ -26,6 +64,47 @@ export default function EventDetailPage() {
     },
     enabled: !!eventId,
   });
+
+  if (event && !initialized.current) {
+    setTitle(event.evtTitle ?? '');
+    setLocation(event.evtLocation ?? '');
+    setStartDate(event.evtStartDt?.slice(0, 10) ?? '');
+    setStartTime(event.evtStartDt?.slice(11, 16) ?? '');
+    setEndDate(event.evtEndDt?.slice(0, 10) ?? '');
+    setEndTime(event.evtEndDt?.slice(11, 16) ?? '');
+    setContent(event.evtContent ?? '');
+    initialized.current = true;
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      api.put(`/api/events/${eventId}`, {
+        teamId: id,
+        evtTitle: title,
+        evtContent: content,
+        evtLocation: location,
+        evtStartDt: startTime ? `${startDate}T${startTime}:00` : startDate,
+        evtEndDt: endTime ? `${endDate}T${endTime}:00` : endDate,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event', eventId] });
+      queryClient.invalidateQueries({ queryKey: ['events', id] });
+      setEditing(false);
+    },
+  });
+
+  const handleCancel = () => {
+    if (event) {
+      setTitle(event.evtTitle ?? '');
+      setLocation(event.evtLocation ?? '');
+      setStartDate(event.evtStartDt?.slice(0, 10) ?? '');
+      setStartTime(event.evtStartDt?.slice(11, 16) ?? '');
+      setEndDate(event.evtEndDt?.slice(0, 10) ?? '');
+      setEndTime(event.evtEndDt?.slice(11, 16) ?? '');
+      setContent(event.evtContent ?? '');
+    }
+    setEditing(false);
+  };
 
   if (isLoading) {
     return <div className="text-center py-20 text-zinc-500 text-sm">불러오는 중...</div>;
@@ -42,46 +121,132 @@ export default function EventDetailPage() {
     );
   }
 
-  // Parse dates
-  const start = new Date(event.evtStartDt);
-  const end = new Date(event.evtEndDt);
-  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
-
-  const dateStr = `${start.getFullYear()}년 ${start.getMonth() + 1}월 ${start.getDate()}일 (${dayNames[start.getDay()]})`;
-
   return (
     <div className="pt-5 px-1">
-      {/* 제목 */}
-      <div className="flex items-center gap-2.5 pb-5 border-b border-zinc-100">
-        <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8} className="shrink-0">
+      {/* 제목 + 수정 버튼 */}
+      <div className="flex items-start gap-2.5 pb-5 border-b border-zinc-100">
+        <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8} className="shrink-0 mt-0.5">
           <path strokeLinecap="round" strokeLinejoin="round"
             d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
         </svg>
-        <h1 className="text-[18px] font-bold text-zinc-900 break-words">{event.evtTitle}</h1>
+        {editing ? (
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="flex-1 text-[18px] font-bold text-zinc-900 border-b-2 border-[#3B3EFF] outline-none bg-transparent"
+          />
+        ) : (
+          <h1 className="flex-1 text-[18px] font-bold text-zinc-900 break-words">{event.evtTitle}</h1>
+        )}
+        {isLeader && !editing && (
+          <button
+            onClick={() => setEditing(true)}
+            className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1 shrink-0"
+          >
+            수정
+          </button>
+        )}
+        {isLeader && editing && (
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={handleCancel}
+              className="text-[13px] font-medium text-zinc-500 border border-zinc-200 rounded-lg px-3 py-1"
+            >
+              취소
+            </button>
+            <button
+              onClick={() => saveMutation.mutate()}
+              disabled={saveMutation.isPending}
+              className="text-[13px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3 py-1 disabled:opacity-60"
+            >
+              완료
+            </button>
+          </div>
+        )}
       </div>
 
       {/* 정보 */}
       <div className="py-5 space-y-4 border-b border-zinc-100">
+        {/* 시작 날짜 */}
         <div className="flex items-center gap-3">
           <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth={2} className="shrink-0">
             <rect x="3" y="4" width="18" height="18" rx="2" strokeLinecap="round" strokeLinejoin="round" />
             <path strokeLinecap="round" strokeLinejoin="round" d="M16 2v4M8 2v4M3 10h18" />
           </svg>
-          <span className="text-[14px] text-zinc-700">
-            {dateStr}
-          </span>
+          {editing ? (
+            <div className="flex flex-col gap-2 flex-1">
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className="flex-1 border-b border-zinc-300 text-[13px] text-zinc-700 outline-none bg-transparent focus:border-[#3B3EFF] py-0.5"
+                />
+                <input
+                  type="time"
+                  value={startTime}
+                  onChange={(e) => setStartTime(e.target.value)}
+                  className="w-24 border-b border-zinc-300 text-[13px] text-zinc-700 outline-none bg-transparent focus:border-[#3B3EFF] py-0.5"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-zinc-400 text-[12px] w-4">~</span>
+                <input
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className="flex-1 border-b border-zinc-300 text-[13px] text-zinc-700 outline-none bg-transparent focus:border-[#3B3EFF] py-0.5"
+                />
+                <input
+                  type="time"
+                  value={endTime}
+                  onChange={(e) => setEndTime(e.target.value)}
+                  className="w-24 border-b border-zinc-300 text-[13px] text-zinc-700 outline-none bg-transparent focus:border-[#3B3EFF] py-0.5"
+                />
+              </div>
+            </div>
+          ) : (
+            <span className="text-[14px] text-zinc-700">
+              {formatDate(event.evtStartDt)}
+              {event.evtStartDt !== event.evtEndDt && ` ~ ${formatDate(event.evtEndDt)}`}
+            </span>
+          )}
         </div>
 
-        {/* Backend Event does not support location and member list yet */}
-        {/* <div className="flex items-center gap-3">...</div> */}
+        {/* 장소 */}
+        <div className="flex items-center gap-3">
+          <svg width="17" height="17" fill="none" viewBox="0 0 24 24" stroke="#9ca3af" strokeWidth={2} className="shrink-0">
+            <path strokeLinecap="round" strokeLinejoin="round"
+              d="M12 2C8.686 2 6 4.686 6 8c0 5.25 6 14 6 14s6-8.75 6-14c0-3.314-2.686-6-6-6z" />
+            <circle cx="12" cy="8" r="2" />
+          </svg>
+          {editing ? (
+            <input
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+              placeholder="장소 미정"
+              className="flex-1 border-b border-zinc-300 text-[14px] text-zinc-700 outline-none bg-transparent focus:border-[#3B3EFF] py-0.5"
+            />
+          ) : (
+            <span className="text-[14px] text-zinc-700">{event.evtLocation || '장소 미정'}</span>
+          )}
+        </div>
       </div>
 
       {/* 상세 */}
       <div className="pt-5">
         <p className="text-[14px] font-semibold text-zinc-900 mb-3">상세</p>
-        {event.evtContent?.split('\n').map((line, i) => (
-          <p key={i} className="text-[14px] text-zinc-600 leading-relaxed">{line}</p>
-        ))}
+        {editing ? (
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            className="w-full h-32 p-3 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] text-zinc-600 outline-none focus:border-[#3B3EFF] resize-none"
+          />
+        ) : (
+          event.evtContent?.split('\n').map((line, i) => (
+            <p key={i} className="text-[14px] text-zinc-600 leading-relaxed">{line}</p>
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/app/[id]/events/new/page.tsx
+++ b/src/app/[id]/events/new/page.tsx
@@ -1,21 +1,31 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
+import { useHeaderSlotStore } from '@/store/headerSlot';
 
 export default function CreateEventPage() {
   const router = useRouter();
   const params = useParams();
   const id = params?.id as string;
   const queryClient = useQueryClient();
+  const { setPageHeader } = useHeaderSlotStore();
+
+  useEffect(() => {
+    setPageHeader({ title: '새 일정 등록하기', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
 
   const [formData, setFormData] = useState({
     evtTitle: '',
     evtContent: '',
+    evtLocation: '',
     startDate: '',
+    startTime: '',
     endDate: '',
+    endTime: '',
   });
 
   const createEventMutation = useMutation({
@@ -39,24 +49,29 @@ export default function CreateEventPage() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const startDt = formData.startTime
+      ? `${formData.startDate}T${formData.startTime}:00`
+      : formData.startDate;
+    const endDt = formData.endDate
+      ? formData.endTime
+        ? `${formData.endDate}T${formData.endTime}:00`
+        : formData.endDate
+      : null;
 
-    const requestData = {
+    createEventMutation.mutate({
       teamId: id,
       evtTitle: formData.evtTitle,
       evtContent: formData.evtContent,
-      evtStartDt: formData.startDate,
-      evtEndDt: formData.endDate,
-    };
-
-    createEventMutation.mutate(requestData);
+      evtLocation: formData.evtLocation,
+      evtStartDt: startDt,
+      ...(endDt && { evtEndDt: endDt }),
+    });
   };
+
+  const inputCls = 'w-full h-12 px-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors placeholder:text-zinc-400';
 
   return (
     <div className="pt-2 px-1 pb-20">
-      <div className="flex items-center justify-between pb-4 mb-4 border-b border-zinc-100">
-        <h1 className="text-[17px] font-bold text-zinc-900">새 일정 추가</h1>
-      </div>
-
       <form onSubmit={handleSubmit} className="space-y-5">
         <div className="space-y-1.5">
           <label className="text-[13px] font-semibold text-zinc-800">일정 제목</label>
@@ -64,31 +79,60 @@ export default function CreateEventPage() {
             type="text"
             required
             placeholder="예) 첫 정기 모임"
-            className="w-full h-12 px-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors placeholder:text-zinc-400"
+            className={inputCls}
             value={formData.evtTitle}
             onChange={(e) => setFormData({ ...formData, evtTitle: e.target.value })}
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1.5">
-            <label className="text-[13px] font-semibold text-zinc-800">시작 날짜</label>
+        <div className="space-y-1.5">
+          <label className="text-[13px] font-semibold text-zinc-800">장소</label>
+          <input
+            type="text"
+            placeholder="예) 스타벅스 홍대점, 온라인 (Zoom)"
+            className={inputCls}
+            value={formData.evtLocation}
+            onChange={(e) => setFormData({ ...formData, evtLocation: e.target.value })}
+          />
+        </div>
+
+        {/* 일시 */}
+        <div className="space-y-1.5">
+          <label className="text-[13px] font-semibold text-zinc-800">일시</label>
+          <div className="grid grid-cols-2 gap-3">
             <input
               type="date"
               required
-              className="w-full h-12 px-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors"
+              className={inputCls}
               value={formData.startDate}
               onChange={(e) => setFormData({ ...formData, startDate: e.target.value })}
             />
+            <input
+              type="time"
+              className={inputCls}
+              value={formData.startTime}
+              onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
+            />
           </div>
-          <div className="space-y-1.5">
-            <label className="text-[13px] font-semibold text-zinc-800">종료 날짜</label>
+        </div>
+
+        {/* 종료 일시 (선택) */}
+        <div className="space-y-1.5">
+          <label className="text-[13px] font-semibold text-zinc-800">
+            종료 일시 <span className="text-[12px] font-normal text-zinc-400">(선택)</span>
+          </label>
+          <div className="grid grid-cols-2 gap-3">
             <input
               type="date"
-              required
-              className="w-full h-12 px-4 bg-zinc-50 border border-zinc-200 rounded-xl text-[14px] outline-none focus:border-[#3B3EFF] focus:bg-white transition-colors"
+              className={inputCls}
               value={formData.endDate}
               onChange={(e) => setFormData({ ...formData, endDate: e.target.value })}
+            />
+            <input
+              type="time"
+              className={inputCls}
+              value={formData.endTime}
+              onChange={(e) => setFormData({ ...formData, endTime: e.target.value })}
             />
           </div>
         </div>
@@ -106,13 +150,13 @@ export default function CreateEventPage() {
 
         <button
           type="submit"
-          disabled={createEventMutation.isPending || !formData.evtTitle.trim() || !formData.startDate || !formData.endDate || !formData.evtContent.trim()}
-          className="w-full h-[52px] mt-6 bg-black text-white rounded-xl text-[15px] font-bold disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors flex items-center justify-center"
+          disabled={createEventMutation.isPending || !formData.evtTitle.trim() || !formData.startDate || !formData.evtContent.trim()}
+          className="w-full h-[52px] mt-6 bg-[#3B3EFF] text-white rounded-xl text-[15px] font-bold disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors flex items-center justify-center"
         >
           {createEventMutation.isPending ? (
             <div className="w-5 h-5 border-2 border-zinc-500 border-t-white rounded-full animate-spin" />
           ) : (
-            '일정 등록하기'
+            '일정 등록'
           )}
         </button>
       </form>

--- a/src/app/[id]/events/page.tsx
+++ b/src/app/[id]/events/page.tsx
@@ -18,9 +18,25 @@ interface EventResponse {
   teamId: string;
 }
 
+interface MemberMe {
+  memRole: string;
+  memState: string;
+}
+
 export default function EventsPage() {
   const { id } = useParams<{ id: string }>();
   const [tab, setTab] = useState<TabType>('다가오는 일정');
+
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data;
+    },
+    enabled: !!id,
+  });
+
+  const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
 
   const { data: eventsData, isLoading } = useQuery({
     queryKey: ['events', id],
@@ -123,17 +139,18 @@ export default function EventsPage() {
         )}
       </div>
 
-      {/* 글쓰기 플로팅 버튼 */}
-      <Link
-        href={`/${id}/events/new`}
-        className="fixed bottom-[80px] right-6 w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg hover:bg-blue-700 transition-colors z-20 max-w-[390px]"
-        style={{ right: 'calc(50% - 195px + 24px)', left: 'auto' }}
-      >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-          <line x1="12" y1="5" x2="12" y2="19" />
-          <line x1="5" y1="12" x2="19" y2="12" />
-        </svg>
-      </Link>
+      {isLeader && (
+        <Link
+          href={`/${id}/events/new`}
+          className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
+          style={{ right: 'calc(50% - 195px + 24px)' }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </Link>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 일정 생성 폼에 장소, 시간 필드 추가
- 종료 일시 선택 사항으로 변경
- 헤더 타이틀 "새 일정 등록하기", 버튼 "일정 등록"으로 변경
- 모임장만 일정 목록에서 + 버튼 표시
- 모임장만 일정 상세에서 인라인 수정 가능 (제목·날짜·시간·장소·내용)

## Test plan
- [ ] 일정 생성 시 장소·시간 입력 및 API 전달 확인
- [ ] 종료 일시 없이도 등록 가능한지 확인
- [ ] 일반 멤버에게 + 버튼/수정 버튼 안 보이는지 확인
- [ ] 모임장 수정 후 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)