### PR TITLE
feat: 공지 수정 페이지 및 목록/상세 UI 개선

### DIFF
--- a/src/app/[id]/notices/[noticeId]/edit/page.tsx
+++ b/src/app/[id]/notices/[noticeId]/edit/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import api from '@/lib/api';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
+const SECTION_LABEL = 'text-[13px] font-semibold text-zinc-600 mb-2 block';
+
+function CheckToggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onChange}
+      className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors shrink-0 ${checked ? 'bg-[#3B3EFF] border-[#3B3EFF]' : 'border-zinc-300 bg-white'
+        }`}
+    >
+      {checked && (
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={3}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+export default function EditNoticePage() {
+  const router = useRouter();
+  const { id, noticeId } = useParams<{ id: string; noticeId: string }>();
+  const queryClient = useQueryClient();
+  const { setPageHeader } = useHeaderSlotStore();
+
+  const [formData, setFormData] = useState({
+    notiTitle: '',
+    notiContent: '',
+    notiFix: 'N',
+    notiRequired: 'N',
+    teamId: id,
+  });
+
+  const { data: notice } = useQuery({
+    queryKey: ['notice', noticeId],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/notices/${noticeId}`);
+      return data.data;
+    },
+    enabled: !!noticeId,
+  });
+
+  useEffect(() => {
+    if (notice) {
+      setFormData({
+        notiTitle: notice.notiTitle,
+        notiContent: notice.notiContent || '',
+        notiFix: notice.notiFix || 'N',
+        notiRequired: notice.notiRequired || 'N',
+        teamId: id,
+      });
+    }
+  }, [notice, id]);
+
+  useEffect(() => {
+    setPageHeader({ title: '공지 수정하기', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
+  const updateMutation = useMutation({
+    mutationFn: async (data: typeof formData) => {
+      const response = await api.put(`/api/notices/${noticeId}`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notices', id] });
+      queryClient.invalidateQueries({ queryKey: ['notice', noticeId] });
+      router.push(`/${id}/notices/${noticeId}`);
+    },
+    onError: (error: any) => {
+      alert(error?.response?.data?.message || '수정에 실패했습니다.');
+    },
+  });
+
+  const isDisabled = updateMutation.isPending || !formData.notiTitle.trim() || !formData.notiContent.trim();
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-5">
+
+      {/* 제목 + 내용 */}
+      <div className="bg-white rounded-xl p-4 flex flex-col gap-4">
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">제목</label>
+          <input
+            type="text"
+            placeholder="공지사항 제목을 입력하세요"
+            className={INPUT_CLS}
+            value={formData.notiTitle}
+            onChange={(e) => setFormData({ ...formData, notiTitle: e.target.value })}
+          />
+        </div>
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">내용</label>
+          <textarea
+            placeholder="공지사항 내용을 상세히 작성해 주세요."
+            rows={8}
+            className={`${INPUT_CLS} resize-none`}
+            value={formData.notiContent}
+            onChange={(e) => setFormData({ ...formData, notiContent: e.target.value })}
+          />
+        </div>
+      </div>
+
+      {/* 옵션 */}
+      <div className="px-1">
+        <label className={SECTION_LABEL}>옵션</label>
+        <div className="bg-white rounded-xl divide-y divide-zinc-100">
+          <div className="flex items-center justify-between px-4 py-3.5">
+            <p className="text-[14px] font-medium text-zinc-800">필독</p>
+            <CheckToggle
+              checked={formData.notiRequired === 'Y'}
+              onChange={() => setFormData({ ...formData, notiRequired: formData.notiRequired === 'Y' ? 'N' : 'Y' })}
+            />
+          </div>
+          <div className="flex items-center justify-between px-4 py-3.5">
+            <p className="text-[14px] font-medium text-zinc-800">상단에 고정하기</p>
+            <CheckToggle
+              checked={formData.notiFix === 'Y'}
+              onChange={() => setFormData({ ...formData, notiFix: formData.notiFix === 'Y' ? 'N' : 'Y' })}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 저장 버튼 */}
+      <button
+        type="button"
+        onClick={() => !isDisabled && updateMutation.mutate(formData)}
+        disabled={isDisabled}
+        className={`mx-1 text-[15px] font-semibold py-3.5 rounded-xl transition-colors flex items-center justify-center ${isDisabled ? 'bg-zinc-300 text-white' : 'bg-[#3B3EFF] text-white'
+          }`}
+      >
+        {updateMutation.isPending ? (
+          <div className="w-5 h-5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+        ) : (
+          '수정하기'
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[id]/notices/[noticeId]/page.tsx
+++ b/src/app/[id]/notices/[noticeId]/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import api from '@/lib/api';
+import { useHeaderSlotStore } from '@/store/headerSlot';
 
 interface NoticeResponse {
   notiId: number;
@@ -14,9 +16,55 @@ interface NoticeResponse {
   teamId: string;
 }
 
+interface MemberResponse {
+  memRole: string;
+  memState: string;
+}
+
+function DeleteConfirmPopup({ onConfirm, onCancel, isPending }: {
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onCancel} />
+      <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-white rounded-2xl shadow-xl w-[280px] overflow-hidden">
+        <div className="px-6 pt-6 pb-5 text-center">
+          <div className="w-11 h-11 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-3">
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#ef4444" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+            </svg>
+          </div>
+          <p className="text-[15px] font-bold text-zinc-900 mb-1">공지를 삭제할까요?</p>
+          <p className="text-[13px] text-zinc-400">삭제된 공지는 복구할 수 없어요.</p>
+        </div>
+        <div className="flex border-t border-zinc-100">
+          <button
+            onClick={onCancel}
+            className="flex-1 py-3.5 text-[14px] font-medium text-zinc-500 border-r border-zinc-100"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isPending}
+            className="flex-1 py-3.5 text-[14px] font-semibold text-red-500"
+          >
+            {isPending ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
 export default function NoticeDetailPage() {
-  const { noticeId } = useParams<{ noticeId: string }>();
+  const { id, noticeId } = useParams<{ id: string; noticeId: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
+  const { setEditSlot } = useHeaderSlotStore();
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const { data: notice, isLoading } = useQuery({
     queryKey: ['notice', noticeId],
@@ -26,6 +74,42 @@ export default function NoticeDetailPage() {
     },
     enabled: !!noticeId,
   });
+
+  const { data: myMembership } = useQuery({
+    queryKey: ['members', 'me', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data as MemberResponse;
+    },
+    enabled: !!id,
+  });
+
+  const isLeader = myMembership?.memRole === 'L' && myMembership?.memState === 'A';
+
+  const deleteMutation = useMutation({
+    mutationFn: async () => {
+      await api.delete(`/api/notices/${noticeId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notices', id] });
+      router.push(`/${id}/notices`);
+    },
+    onError: (error: any) => {
+      alert(error?.response?.data?.message || '삭제에 실패했습니다.');
+    },
+  });
+
+  useEffect(() => {
+    if (!isLeader) return;
+    setEditSlot({
+      editing: false,
+      onEdit: () => router.push(`/${id}/notices/${noticeId}/edit`),
+      onSave: () => {},
+      onCancel: () => {},
+      onDelete: () => setDeleteOpen(true),
+    });
+    return () => setEditSlot(null);
+  }, [isLeader, id, noticeId]);
 
   if (isLoading) {
     return <div className="text-center py-20 text-zinc-500 text-sm">불러오는 중...</div>;
@@ -44,16 +128,9 @@ export default function NoticeDetailPage() {
     <div className="pt-5 px-1">
       {/* 제목 */}
       <div className="pb-5 border-b border-zinc-100">
-        <div className="flex items-center gap-2 mb-2">
-          {notice.notiFix === 'Y' && (
-            <span className="text-[11px] font-semibold text-white bg-[#3B3EFF] rounded-full px-2 py-0.5 shrink-0">
-              필독
-            </span>
-          )}
-          {notice.notiFix === 'Y' && (
-            <span className="text-[11px] font-medium text-zinc-400">고정됨</span>
-          )}
-        </div>
+        {notice.notiFix === 'Y' && (
+          <p className="text-[11px] font-medium text-zinc-400 mb-2">고정됨</p>
+        )}
         <h1 className="text-[18px] font-bold text-zinc-900 break-words">{notice.notiTitle}</h1>
       </div>
 
@@ -81,6 +158,14 @@ export default function NoticeDetailPage() {
           <p key={i} className="text-[14px] text-zinc-700 leading-relaxed mb-1">{line}</p>
         ))}
       </div>
+
+      {deleteOpen && (
+        <DeleteConfirmPopup
+          onConfirm={() => deleteMutation.mutate()}
+          onCancel={() => setDeleteOpen(false)}
+          isPending={deleteMutation.isPending}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/[id]/notices/page.tsx
+++ b/src/app/[id]/notices/page.tsx
@@ -11,6 +11,7 @@ interface NoticeResponse {
   notiTitle: string;
   notiContent: string;
   notiFix: string;
+  notiRequired: string;
   regDtm: string;
   modDtm: string;
   teamId: string;
@@ -29,7 +30,7 @@ function PinIcon() {
 
 function NoticeItem({ notice, id }: { notice: NoticeResponse; id: string }) {
   const isPinned = notice.notiFix === 'Y';
-  const isRequired = notice.notiFix === 'Y'; // Treating fixed as required for now
+  const isRequired = notice.notiRequired === 'Y';
 
   return (
     <Link
@@ -81,15 +82,6 @@ export default function NoticesPage() {
 
   return (
     <div className="pt-2">
-      {/* 고정 공지 */}
-      {pinned.length > 0 && (
-        <div className="mb-4">
-          {pinned.map((notice) => (
-            <NoticeItem key={notice.notiId} notice={notice} id={id} />
-          ))}
-        </div>
-      )}
-
       {/* 정렬 */}
       <div className="flex items-center justify-center mb-1 pb-3 border-b border-zinc-100">
         <button
@@ -107,9 +99,20 @@ export default function NoticesPage() {
         </button>
       </div>
 
+      {/* 고정 공지 */}
+      {pinned.length > 0 && (
+        <div className="mb-4">
+          {pinned.map((notice) => (
+            <NoticeItem key={notice.notiId} notice={notice} id={id} />
+          ))}
+        </div>
+      )}
+
       {/* 일반 공지 목록 */}
       <div className="pb-20">
-        {rest.length === 0 && <div className="text-center py-10 text-zinc-500 text-sm">등록된 공지가 없습니다.</div>}
+        {rest.length === 0 && pinned.length === 0 && (
+          <div className="text-center py-10 text-zinc-500 text-sm">등록된 공지가 없습니다.</div>
+        )}
         {rest.map((notice) => (
           <NoticeItem key={notice.notiId} notice={notice} id={id} />
         ))}


### PR DESCRIPTION
## Summary
- 공지 수정 페이지 신규 (`/[id]/notices/[noticeId]/edit`)
- 공지 목록 UI 개선
- 공지 상세 UI 개선

## Test plan
- [ ] 공지 상세에서 수정 페이지 진입 확인
- [ ] 수정 후 저장 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)