### PR TITLE
feat: 미션 팀장/멤버 뷰 분리 및 인증 플로우 완성

### DIFF
--- a/src/app/[id]/_components/GroupHeader.tsx
+++ b/src/app/[id]/_components/GroupHeader.tsx
@@ -28,6 +28,7 @@ export default function GroupHeader() {
     else if (pathname.includes('/notices/')) backHref = `/${segments[1]}/notices`;
     else if (pathname.includes('/votes/')) backHref = `/${segments[1]}/votes`;
     else if (pathname.includes('/minutes/')) backHref = `/${segments[1]}/minutes`;
+    else if (pathname.includes('/missions/')) backHref = `/${segments[1]}/missions`;
   }
 
   return (

--- a/src/app/[id]/_components/GroupNav.tsx
+++ b/src/app/[id]/_components/GroupNav.tsx
@@ -20,7 +20,7 @@ export default function GroupNav({ groupId }: { groupId: string }) {
   const segments = pathname.split('/');
   const isDetailPage =
     segments.length >= 4 &&
-    (pathname.includes('/events/') || pathname.includes('/notices/') || pathname.includes('/votes/') || pathname.includes('/minutes/'));
+    (pathname.includes('/events/') || pathname.includes('/notices/') || pathname.includes('/votes/') || pathname.includes('/minutes/') || pathname.includes('/missions/'));
   if (isDetailPage) return null;
 
   return (

--- a/src/app/[id]/missions/[missionId]/pending/page.tsx
+++ b/src/app/[id]/missions/[missionId]/pending/page.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useSearchParams, useRouter } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
+
+// TODO: 백엔드 연결 시 API로 교체
+const MOCK_SUBMISSION_AI = {
+  submittedAt: '2025-05-18 14:32',
+  images: 2,
+  text: '',
+  fileName: '',
+  rejectionReason: '',
+};
+const MOCK_SUBMISSION_MANUAL = {
+  submittedAt: '2025-05-18 11:10',
+  images: 0,
+  text: '채식주의자를 읽고 주인공 영혜의 심리 변화에 대해 감상문을 작성했습니다. 영혜가 꿈을 통해 폭력성을 인식하고 채식을 선택하는 과정이 인상 깊었습니다.',
+  fileName: '감상문_한강_채식주의자.pdf',
+  rejectionReason: '제출하신 파일이 미션 내용과 맞지 않아요.',
+};
+
+type Status = 'pending' | 'completed' | 'failed';
+
+const HEADER_TITLE: Record<Status, string> = {
+  pending: '제출한 인증',
+  completed: '인증 완료',
+  failed: '인증 실패',
+};
+
+function MissionInfoCard({ scope, authType, title, subtitle, isAI }: {
+  scope: string; authType: string; title: string; subtitle: string; isAI: boolean;
+}) {
+  return (
+    <div className="bg-white rounded-xl p-4 flex items-start gap-3">
+      <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+        {isAI ? (
+          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+          </svg>
+        ) : (
+          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+          </svg>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex gap-1.5 mb-1.5">
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[scope] ?? '#FF9E6A' }}>{scope}</span>
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[authType] ?? '#3B3EFF' }}>{authType}</span>
+        </div>
+        <p className="text-[14px] font-bold text-zinc-900 leading-snug">{title}</p>
+        <p className="text-[12px] text-zinc-400 mt-0.5">{subtitle}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function MissionPendingPage() {
+  const { id, missionId } = useParams<{ id: string; missionId: string }>();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setPageHeader } = useHeaderSlotStore();
+
+  const authType = searchParams.get('authType') ?? 'AI인증';
+  const scope = searchParams.get('scope') ?? '공통';
+  const title = searchParams.get('title') ?? '';
+  const subtitle = searchParams.get('subtitle') ?? '';
+  const status = (searchParams.get('status') ?? 'pending') as Status;
+  const isAI = authType === 'AI인증';
+  const submission = isAI ? MOCK_SUBMISSION_AI : MOCK_SUBMISSION_MANUAL;
+
+  useEffect(() => {
+    setPageHeader({ title: HEADER_TITLE[status], hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader, status]);
+
+  const verifyHref = `/${id}/missions/${missionId}/verify?authType=${encodeURIComponent(authType)}&scope=${encodeURIComponent(scope)}&title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(subtitle)}`;
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
+
+      <MissionInfoCard scope={scope} authType={authType} title={title} subtitle={subtitle} isAI={isAI} />
+
+      {/* 상태 배너 */}
+      {status === 'pending' && (
+        <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-amber-50 flex items-center justify-center shrink-0">
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#f59e0b" strokeWidth={2}>
+              <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+            </svg>
+          </div>
+          <div className="flex-1">
+            <p className="text-[13px] font-semibold text-zinc-800">승인 대기 중</p>
+            <p className="text-[11px] text-zinc-400 mt-0.5">제출일: {submission.submittedAt}</p>
+          </div>
+          <span className="text-[11px] font-semibold text-amber-500 bg-amber-50 px-2.5 py-1 rounded-full">대기</span>
+        </div>
+      )}
+
+      {status === 'completed' && (
+        <div className="bg-emerald-50 rounded-xl px-4 py-3.5 flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center shrink-0">
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#10b981" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+          <div className="flex-1">
+            <p className="text-[13px] font-semibold text-zinc-800">인증이 완료됐어요!</p>
+            <p className="text-[11px] text-zinc-400 mt-0.5">제출일: {submission.submittedAt}</p>
+          </div>
+          <span className="text-[11px] font-semibold text-emerald-600 bg-emerald-100 px-2.5 py-1 rounded-full">완료</span>
+        </div>
+      )}
+
+      {status === 'failed' && (
+        <div className="bg-red-50 rounded-xl px-4 py-3.5 flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-red-100 flex items-center justify-center shrink-0">
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#ef4444" strokeWidth={2.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </div>
+          <div className="flex-1">
+            <p className="text-[13px] font-semibold text-zinc-800">
+              {isAI ? 'AI가 인식하지 못했어요' : '인증이 거절됐어요'}
+            </p>
+            <p className="text-[11px] text-zinc-400 mt-0.5">제출일: {submission.submittedAt}</p>
+          </div>
+          <span className="text-[11px] font-semibold text-red-500 bg-red-100 px-2.5 py-1 rounded-full">실패</span>
+        </div>
+      )}
+
+      {/* 거절 사유 (수동인증 실패 시) */}
+      {status === 'failed' && !isAI && submission.rejectionReason && (
+        <div className="flex flex-col gap-2">
+          <p className="text-[14px] font-semibold text-zinc-800">거절 사유</p>
+          <div className="bg-white rounded-xl p-4 border border-red-100">
+            <p className="text-[13px] text-zinc-600 leading-relaxed">{submission.rejectionReason}</p>
+          </div>
+        </div>
+      )}
+
+      {/* 제출 내용 */}
+      {isAI ? (
+        <>
+          <p className="text-[14px] font-semibold text-zinc-800">제출한 사진</p>
+          <div className="flex gap-2.5">
+            {/* TODO: 백엔드 연결 시 실제 이미지 URL로 교체 */}
+            {Array.from({ length: submission.images }).map((_, i) => (
+              <div key={i} className="w-[88px] h-[88px] rounded-xl bg-zinc-200 shrink-0 flex items-center justify-center">
+                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="#a1a1aa" strokeWidth={1.5}>
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <circle cx="8.5" cy="8.5" r="1.5" />
+                  <polyline points="21 15 16 10 5 21" />
+                </svg>
+              </div>
+            ))}
+          </div>
+          {status === 'pending' && (
+            <div className="flex items-start gap-2 bg-[#EEF0FF] rounded-xl px-4 py-3">
+              <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={2} className="shrink-0 mt-0.5">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              <p className="text-[12px] text-[#3B3EFF] leading-relaxed">AI가 사진을 분석 중이에요. 인증 결과는 보통 1분 이내에 나와요.</p>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <p className="text-[14px] font-semibold text-zinc-800">인증 내용</p>
+            <div className="bg-white rounded-xl p-4">
+              <p className="text-[14px] text-zinc-700 leading-relaxed whitespace-pre-wrap">{submission.text}</p>
+            </div>
+          </div>
+          {submission.fileName && (
+            <div className="flex flex-col gap-2">
+              <p className="text-[14px] font-semibold text-zinc-800">첨부 파일</p>
+              <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
+                <div className="w-9 h-9 rounded-lg bg-[#EBEBFF] flex items-center justify-center shrink-0">
+                  <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66L9.41 17.41a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+                  </svg>
+                </div>
+                <p className="text-[13px] text-zinc-800 truncate">{submission.fileName}</p>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* 다시 제출하기 (실패 시) */}
+      {status === 'failed' && (
+        <button
+          onClick={() => router.push(verifyHref)}
+          className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold mt-2"
+        >
+          다시 제출하기
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/[id]/missions/[missionId]/submissions/[submissionId]/page.tsx
+++ b/src/app/[id]/missions/[missionId]/submissions/[submissionId]/page.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
+
+// TODO: 백엔드 연결 시 submissionId로 fetch
+const MOCK_DETAIL_AI = {
+  submittedAt: '2025-05-18 14:32',
+  images: 2,
+  text: '',
+  fileName: '',
+};
+const MOCK_DETAIL_MANUAL = {
+  submittedAt: '2025-05-18 11:40',
+  images: 0,
+  text: '채식주의자를 읽고 주인공 영혜의 심리 변화에 대해 감상문을 작성했습니다. 영혜가 꿈을 통해 폭력성을 인식하고 채식을 선택하는 과정이 인상 깊었습니다.',
+  fileName: '감상문_한강_채식주의자.pdf',
+};
+
+function RejectPopup({ onConfirm, onCancel }: {
+  onConfirm: (reason: string) => void;
+  onCancel: () => void;
+}) {
+  const [reason, setReason] = useState('');
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onCancel} />
+      <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-white rounded-2xl shadow-xl w-[300px] overflow-hidden">
+        <div className="px-5 pt-5 pb-4">
+          <p className="text-[15px] font-bold text-zinc-900 mb-1">인증을 거절할까요?</p>
+          <p className="text-[12px] text-zinc-400 mb-3">거절 사유를 작성하면 멤버에게 전달돼요. (선택)</p>
+          <textarea
+            className="w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[13px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] resize-none h-24 transition-colors"
+            placeholder="거절 사유를 입력해주세요."
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            maxLength={200}
+          />
+          <p className="text-[11px] text-zinc-300 text-right mt-1">{reason.length}/200</p>
+        </div>
+        <div className="flex border-t border-zinc-100">
+          <button onClick={onCancel} className="flex-1 py-3.5 text-[14px] font-medium text-zinc-500 border-r border-zinc-100">
+            취소
+          </button>
+          <button onClick={() => onConfirm(reason)} className="flex-1 py-3.5 text-[14px] font-semibold text-red-500">
+            거절
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function SubmissionDetailPage() {
+  useParams<{ id: string; missionId: string; submissionId: string }>();
+  const searchParams = useSearchParams();
+  const { setPageHeader } = useHeaderSlotStore();
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [decision, setDecision] = useState<'approved' | 'rejected' | null>(null);
+
+  const authType = searchParams.get('authType') ?? 'AI인증';
+  const scope = searchParams.get('scope') ?? '공통';
+  const title = searchParams.get('title') ?? '';
+  const subtitle = searchParams.get('subtitle') ?? '';
+  const memberName = searchParams.get('memberName') ?? '멤버';
+  const aiResult = searchParams.get('aiResult') ?? '';
+  const isAI = authType === 'AI인증';
+  const detail = isAI ? MOCK_DETAIL_AI : MOCK_DETAIL_MANUAL;
+
+  useEffect(() => {
+    setPageHeader({ title: '인증 확인', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
+  const handleApprove = () => {
+    // TODO: 백엔드 연결 시 API 호출
+    setDecision('approved');
+  };
+
+  const handleReject = (_reason: string) => {
+    // TODO: 백엔드 연결 시 API 호출 (reason 포함)
+    setRejectOpen(false);
+    setDecision('rejected');
+  };
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
+
+      {/* 미션 정보 */}
+      <div className="bg-white rounded-xl p-4 flex items-start gap-3">
+        <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+          {isAI ? (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+            </svg>
+          ) : (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex gap-1.5 mb-1.5">
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[scope] ?? '#FF9E6A' }}>{scope}</span>
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[authType] ?? '#3B3EFF' }}>{authType}</span>
+          </div>
+          <p className="text-[14px] font-bold text-zinc-900 leading-snug">{title}</p>
+          <p className="text-[12px] text-zinc-400 mt-0.5">{subtitle}</p>
+        </div>
+      </div>
+
+      {/* 제출자 + AI 결과 */}
+      <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
+        <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
+          <span className="text-[13px] font-bold text-white">{memberName[0]}</span>
+        </div>
+        <div className="flex-1">
+          <p className="text-[13px] font-semibold text-zinc-800">{memberName}</p>
+          <p className="text-[11px] text-zinc-400 mt-0.5">제출일: {detail.submittedAt}</p>
+        </div>
+        {isAI && aiResult && (
+          <div className={`flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-semibold ${aiResult === 'approved' ? 'bg-emerald-50 text-emerald-600' : 'bg-red-50 text-red-500'}`}>
+            <svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+              {aiResult === 'approved'
+                ? <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                : <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />}
+            </svg>
+            AI {aiResult === 'approved' ? '승인' : '거절'}
+          </div>
+        )}
+      </div>
+
+      {/* 처리 결과 배너 */}
+      {decision === 'approved' && (
+        <div className="bg-emerald-50 rounded-xl px-4 py-3 flex items-center gap-2">
+          <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#10b981" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+          <p className="text-[13px] font-semibold text-emerald-700">인증을 승인했어요.</p>
+        </div>
+      )}
+      {decision === 'rejected' && (
+        <div className="bg-red-50 rounded-xl px-4 py-3 flex items-center gap-2">
+          <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#ef4444" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <p className="text-[13px] font-semibold text-red-600">인증을 거절했어요.</p>
+        </div>
+      )}
+
+      {/* 제출 내용 */}
+      {isAI ? (
+        <>
+          <p className="text-[14px] font-semibold text-zinc-800">제출한 사진</p>
+          <div className="flex gap-2.5">
+            {Array.from({ length: detail.images }).map((_, i) => (
+              <div key={i} className="w-[88px] h-[88px] rounded-xl bg-zinc-200 shrink-0 flex items-center justify-center">
+                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="#a1a1aa" strokeWidth={1.5}>
+                  <rect x="3" y="3" width="18" height="18" rx="2" />
+                  <circle cx="8.5" cy="8.5" r="1.5" />
+                  <polyline points="21 15 16 10 5 21" />
+                </svg>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <p className="text-[14px] font-semibold text-zinc-800">인증 내용</p>
+            <div className="bg-white rounded-xl p-4">
+              <p className="text-[14px] text-zinc-700 leading-relaxed whitespace-pre-wrap">{detail.text}</p>
+            </div>
+          </div>
+          {detail.fileName && (
+            <div className="flex flex-col gap-2">
+              <p className="text-[14px] font-semibold text-zinc-800">첨부 파일</p>
+              <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
+                <div className="w-9 h-9 rounded-lg bg-[#EBEBFF] flex items-center justify-center shrink-0">
+                  <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66L9.41 17.41a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+                  </svg>
+                </div>
+                <p className="text-[13px] text-zinc-800 truncate">{detail.fileName}</p>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* 승인 / 거절 버튼 */}
+      {!decision && (
+        <div className="flex gap-3 mt-2">
+          <button
+            onClick={() => setRejectOpen(true)}
+            className="flex-1 h-[52px] border border-red-400 text-red-500 rounded-2xl text-[15px] font-semibold"
+          >
+            거절
+          </button>
+          <button
+            onClick={handleApprove}
+            className="flex-1 h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold"
+          >
+            승인
+          </button>
+        </div>
+      )}
+
+      {rejectOpen && <RejectPopup onConfirm={handleReject} onCancel={() => setRejectOpen(false)} />}
+    </div>
+  );
+}

--- a/src/app/[id]/missions/[missionId]/submissions/page.tsx
+++ b/src/app/[id]/missions/[missionId]/submissions/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useSearchParams, useRouter } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const MOCK_SUBMISSIONS = [
+  { id: '1', memberName: '김철수', initial: '김', submittedAt: '14:32', authType: 'AI인증',   status: 'pending',   aiResult: 'approved' },
+  { id: '2', memberName: '이영희', initial: '이', submittedAt: '13:15', authType: 'AI인증',   status: 'failed',    aiResult: 'rejected' },
+  { id: '3', memberName: '박지수', initial: '박', submittedAt: '11:40', authType: '수동인증',  status: 'pending',   aiResult: null },
+  { id: '4', memberName: '최민준', initial: '최', submittedAt: '10:05', authType: '수동인증',  status: 'completed', aiResult: null },
+];
+
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
+
+const STATUS_LABEL: Record<string, { text: string; color: string; bg: string }> = {
+  pending:   { text: '대기', color: '#f59e0b', bg: '#fffbeb' },
+  completed: { text: '완료', color: '#10b981', bg: '#ecfdf5' },
+  failed:    { text: '거절', color: '#ef4444', bg: '#fef2f2' },
+};
+
+function resolvedStatus(s: typeof MOCK_SUBMISSIONS[0]) {
+  if (s.authType === 'AI인증' && s.aiResult === 'approved') return 'completed';
+  return s.status;
+}
+
+export default function SubmissionsPage() {
+  const { id, missionId } = useParams<{ id: string; missionId: string }>();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setPageHeader } = useHeaderSlotStore();
+  const title = searchParams.get('title') ?? '미션';
+  const authType = searchParams.get('authType') ?? 'AI인증';
+  const scope = searchParams.get('scope') ?? '공통';
+  const subtitle = searchParams.get('subtitle') ?? '';
+  const isAI = authType === 'AI인증';
+
+  useEffect(() => {
+    setPageHeader({ title: '제출 현황', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
+  const byType = MOCK_SUBMISSIONS.filter((s) => s.authType === authType);
+  const pendingCount = byType.filter((s) => resolvedStatus(s) === 'pending').length;
+  const completedCount = byType.filter((s) => resolvedStatus(s) === 'completed').length;
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
+
+      {/* 미션 정보 */}
+      <div className="bg-white rounded-xl p-4 flex items-start gap-3">
+        <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+          {isAI ? (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" /><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+            </svg>
+          ) : (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" /><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex gap-1.5 mb-1.5">
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[scope] ?? '#FF9E6A' }}>{scope}</span>
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[authType] ?? '#3B3EFF' }}>{authType}</span>
+          </div>
+          <p className="text-[14px] font-bold text-zinc-900 leading-snug">{title}</p>
+          <p className="text-[12px] text-zinc-400 mt-0.5">{subtitle}</p>
+        </div>
+      </div>
+
+      {/* 통계 */}
+      <div className="bg-white rounded-xl p-4">
+        <div className="flex gap-3">
+          <div className="flex-1 bg-zinc-50 rounded-lg py-2.5 flex flex-col items-center gap-0.5">
+            <span className="text-[18px] font-bold text-amber-500">{pendingCount}</span>
+            <span className="text-[11px] text-zinc-400">대기</span>
+          </div>
+          <div className="flex-1 bg-zinc-50 rounded-lg py-2.5 flex flex-col items-center gap-0.5">
+            <span className="text-[18px] font-bold text-emerald-500">{completedCount}</span>
+            <span className="text-[11px] text-zinc-400">완료</span>
+          </div>
+          <div className="flex-1 bg-zinc-50 rounded-lg py-2.5 flex flex-col items-center gap-0.5">
+            <span className="text-[18px] font-bold text-zinc-800">{byType.length}</span>
+            <span className="text-[11px] text-zinc-400">전체</span>
+          </div>
+        </div>
+      </div>
+
+      {/* 제출 목록 */}
+      <div className="flex flex-col gap-2">
+        {byType.length === 0 ? (
+          <p className="text-center text-[13px] text-zinc-400 py-10">제출 내역이 없습니다.</p>
+        ) : byType.map((s) => {
+          const status = resolvedStatus(s);
+          const st = STATUS_LABEL[status];
+          const href = `/${id}/missions/${missionId}/submissions/${s.id}?authType=${encodeURIComponent(s.authType)}&scope=${encodeURIComponent(scope)}&title=${encodeURIComponent(title)}&subtitle=${encodeURIComponent(subtitle)}&memberName=${encodeURIComponent(s.memberName)}&aiResult=${s.aiResult ?? ''}`;
+          return (
+            <button key={s.id} onClick={() => router.push(href)}
+              className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3 text-left w-full">
+              <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
+                <span className="text-[13px] font-bold text-white">{s.initial}</span>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-semibold text-zinc-900">{s.memberName}</p>
+                {s.authType === 'AI인증' && s.aiResult && (
+                  <span className={`text-[10px] font-medium mt-0.5 ${s.aiResult === 'approved' ? 'text-emerald-500' : 'text-red-400'}`}>
+                    AI {s.aiResult === 'approved' ? '승인' : '거절'}
+                  </span>
+                )}
+              </div>
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full" style={{ color: st.color, backgroundColor: st.bg }}>
+                  {st.text}
+                </span>
+                <span className="text-[11px] text-zinc-400">{s.submittedAt}</span>
+              </div>
+              <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="#d4d4d8" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+              </svg>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[id]/missions/[missionId]/verify/page.tsx
+++ b/src/app/[id]/missions/[missionId]/verify/page.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useParams, useSearchParams, useRouter } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
+
+export default function MissionVerifyPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { setPageHeader } = useHeaderSlotStore();
+
+  const authType = searchParams.get('authType') ?? 'AI인증';
+  const scope = searchParams.get('scope') ?? '공통';
+  const title = searchParams.get('title') ?? '';
+  const subtitle = searchParams.get('subtitle') ?? '';
+  const isAI = authType === 'AI인증';
+
+  const [images, setImages] = useState<string[]>([]);
+  const [text, setText] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const attachInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setPageHeader({ title: '미션 인증하기', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
+  const handleImageAdd = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    files.forEach((f) => {
+      const url = URL.createObjectURL(f);
+      setImages((prev) => (prev.length < 3 ? [...prev, url] : prev));
+    });
+    e.target.value = '';
+  };
+
+  const handleRemoveImage = (i: number) => {
+    setImages((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const canSubmit = isAI ? images.length > 0 : text.trim().length > 0;
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
+
+      {/* 미션 정보 카드 */}
+      <div className="bg-white rounded-xl p-4 flex items-start gap-3">
+        <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center shrink-0">
+          {isAI ? (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+            </svg>
+          ) : (
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#6366f1" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 20h9" />
+              <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+            </svg>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex gap-1.5 mb-1.5">
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[scope] ?? '#FF9E6A' }}>
+              {scope}
+            </span>
+            <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[authType] ?? '#3B3EFF' }}>
+              {authType}
+            </span>
+          </div>
+          <p className="text-[14px] font-bold text-zinc-900 leading-snug">{title}</p>
+          <p className="text-[12px] text-zinc-400 mt-0.5">{subtitle}</p>
+        </div>
+      </div>
+
+      {isAI ? (
+        /* AI 인증 */
+        <>
+          <div className="flex flex-col gap-3">
+            <p className="text-[14px] font-semibold text-zinc-800">인증 사진 첨부</p>
+            <div className="flex gap-2.5">
+              {images.map((src, i) => (
+                <div key={i} className="relative w-[88px] h-[88px] rounded-xl overflow-hidden bg-zinc-100 shrink-0">
+                  <img src={src} alt="" className="w-full h-full object-cover" />
+                  <button
+                    onClick={() => handleRemoveImage(i)}
+                    className="absolute top-1 right-1 w-5 h-5 bg-white/80 rounded-full flex items-center justify-center"
+                  >
+                    <svg width="10" height="10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+              {images.length < 3 && (
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  className="w-[88px] h-[88px] rounded-xl border-2 border-dashed border-zinc-200 hover:border-[#3B3EFF] flex items-center justify-center text-[#3B3EFF] shrink-0 transition-colors"
+                >
+                  <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <line x1="12" y1="5" x2="12" y2="19" />
+                    <line x1="5" y1="12" x2="19" y2="12" />
+                  </svg>
+                </button>
+              )}
+            </div>
+            <input ref={fileInputRef} type="file" accept="image/*" multiple className="hidden" onChange={handleImageAdd} />
+          </div>
+
+          {/* AI 안내 */}
+          <div className="flex items-start gap-2 bg-[#EEF0FF] rounded-xl px-4 py-3">
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={2} className="shrink-0 mt-0.5">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            <p className="text-[12px] text-[#3B3EFF] leading-relaxed">
+              AI가 사진을 자동으로 분석해요.
+            </p>
+          </div>
+        </>
+      ) : (
+        /* 수동 인증 */
+        <>
+          <div className="flex flex-col gap-2">
+            <p className="text-[14px] font-semibold text-zinc-800">인증 내용 작성</p>
+            <div className="bg-white rounded-xl p-4 flex flex-col gap-1.5">
+              <textarea
+                className="w-full h-28 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none resize-none bg-transparent"
+                placeholder="인증 내용을 간단히 설명해주세요."
+                maxLength={300}
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+              />
+              <p className="text-[12px] text-zinc-300 text-right">{text.length}/300</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-[14px] font-semibold text-zinc-800">
+              파일 또는 사진 첨부 <span className="text-zinc-400 font-normal text-[13px]">(선택)</span>
+            </label>
+            <button
+              onClick={() => attachInputRef.current?.click()}
+              className="w-full border-2 border-dashed border-[#3B3EFF]/50 rounded-xl bg-white px-6 py-10 flex flex-col items-center gap-3 transition-colors hover:border-[#3B3EFF] hover:bg-blue-50"
+            >
+              <div className="w-14 h-14 rounded-2xl bg-[#EBEBFF] flex items-center justify-center">
+                <svg width="30" height="30" fill="none" viewBox="0 0 24 24">
+                  <path d="M12 15V4M12 4L8.5 7.5M12 4L15.5 7.5" stroke="#3B3EFF" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M4 17v1.75C4 19.993 4.895 21 6 21h12c1.105 0 2-1.007 2-2.25V17" stroke="#3B3EFF" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </div>
+              <p className="text-[15px] font-bold text-zinc-800">
+                {file ? file.name : '파일 첨부하기'}
+              </p>
+              <p className="text-[13px] text-zinc-400 text-center leading-relaxed">
+                탭하여 파일을 선택하거나 여기로 끌어다 놓으세요
+              </p>
+            </button>
+            <input ref={attachInputRef} type="file" className="hidden" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+          </div>
+        </>
+      )}
+
+      {/* 제출 버튼 */}
+      <button
+        disabled={!canSubmit}
+        className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors mt-2"
+      >
+        인증 제출하기
+      </button>
+    </div>
+  );
+}

--- a/src/app/[id]/missions/new/page.tsx
+++ b/src/app/[id]/missions/new/page.tsx
@@ -6,6 +6,13 @@ import { useHeaderSlotStore } from '@/store/headerSlot';
 
 const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
 
+// TODO: 백엔드 연결 시 API로 교체
+const MOCK_MEMBERS = [
+  { id: 'M1', name: '김철수', initial: '김' },
+  { id: 'M2', name: '이영희', initial: '이' },
+  { id: 'M3', name: '박지수', initial: '박' },
+];
+
 export default function MissionNewPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -16,6 +23,7 @@ export default function MissionNewPage() {
 
   const [title, setTitle] = useState('');
   const [scope, setScope] = useState<'공통' | '개인'>('공통');
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [content, setContent] = useState('');
@@ -30,7 +38,7 @@ export default function MissionNewPage() {
     return () => setPageHeader(null);
   }, [setPageHeader, isForm]);
 
-  const canSubmit = title.trim() && startDate && endDate && content.trim();
+  const canSubmit = title.trim() && startDate && endDate && content.trim() && (scope === '공통' || !!selectedMemberId);
 
   return (
     <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
@@ -49,13 +57,13 @@ export default function MissionNewPage() {
         </div>
 
         {/* 대상자 */}
-        <div>
-          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">대상자</label>
+        <div className="flex flex-col gap-2">
+          <label className="block text-[13px] font-medium text-zinc-500">대상자</label>
           <div className="flex gap-2">
             {(['공통', '개인'] as const).map((s) => (
               <button
                 key={s}
-                onClick={() => setScope(s)}
+                onClick={() => { setScope(s); setSelectedMemberId(null); }}
                 className={`flex-1 py-2.5 rounded-lg border text-[14px] font-medium transition-colors ${
                   scope === s ? 'bg-[#3B3EFF] border-[#3B3EFF] text-white' : 'border-zinc-200 text-zinc-400 bg-white'
                 }`}
@@ -64,6 +72,30 @@ export default function MissionNewPage() {
               </button>
             ))}
           </div>
+          {scope === '개인' && (
+            <div className="flex flex-col gap-2">
+              <p className="text-[12px] text-zinc-400">부여할 멤버를 선택해주세요.</p>
+              {MOCK_MEMBERS.map((mem) => (
+                <button
+                  key={mem.id}
+                  onClick={() => setSelectedMemberId(mem.id)}
+                  className={`flex items-center gap-3 px-3 py-2.5 rounded-lg border transition-colors ${
+                    selectedMemberId === mem.id ? 'border-[#3B3EFF] bg-[#EBEBFF]' : 'border-zinc-200 bg-white'
+                  }`}
+                >
+                  <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
+                    <span className="text-[12px] font-bold text-white">{mem.initial}</span>
+                  </div>
+                  <span className={`text-[14px] font-medium ${selectedMemberId === mem.id ? 'text-[#3B3EFF]' : 'text-zinc-800'}`}>{mem.name}</span>
+                  {selectedMemberId === mem.id && (
+                    <svg className="ml-auto" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={2.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* 시작일 / 마감일 */}

--- a/src/app/[id]/missions/new/page.tsx
+++ b/src/app/[id]/missions/new/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
+
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
+
+export default function MissionNewPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const kind = searchParams.get('kind');
+  const isForm = kind === 'form';
+
+  const { setPageHeader } = useHeaderSlotStore();
+
+  const [title, setTitle] = useState('');
+  const [scope, setScope] = useState<'공통' | '개인'>('공통');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [content, setContent] = useState('');
+  const [useAI, setUseAI] = useState(true);
+  const [formItems, setFormItems] = useState(['', '']);
+
+  useEffect(() => {
+    setPageHeader({
+      title: `미션 생성 · ${isForm ? '자동 폼' : '자유형식'}`,
+      hideHamburger: true,
+    });
+    return () => setPageHeader(null);
+  }, [setPageHeader, isForm]);
+
+  const canSubmit = title.trim() && startDate && endDate && content.trim();
+
+  return (
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-5 pb-8 flex flex-col gap-4">
+
+      {/* 기본 정보 카드 */}
+      <div className="bg-white rounded-xl p-4 flex flex-col gap-4">
+        {/* 미션명 */}
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">미션명</label>
+          <input
+            className={INPUT_CLS}
+            placeholder="예) 책 읽고 인증하기"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        {/* 대상자 */}
+        <div>
+          <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">대상자</label>
+          <div className="flex gap-2">
+            {(['공통', '개인'] as const).map((s) => (
+              <button
+                key={s}
+                onClick={() => setScope(s)}
+                className={`flex-1 py-2.5 rounded-lg border text-[14px] font-medium transition-colors ${
+                  scope === s ? 'bg-[#3B3EFF] border-[#3B3EFF] text-white' : 'border-zinc-200 text-zinc-400 bg-white'
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 시작일 / 마감일 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">미션 시작일</label>
+            <input
+              type="date"
+              className={INPUT_CLS}
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">미션 마감일</label>
+            <input
+              type="date"
+              className={INPUT_CLS}
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 미션 내용 카드 */}
+      <div className="bg-white rounded-xl p-4">
+        <label className="block text-[13px] font-medium text-zinc-500 mb-1.5">미션 내용</label>
+        <textarea
+          className={`${INPUT_CLS} resize-none h-28`}
+          placeholder="미션에 대해 자세히 설명해 주세요."
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+      </div>
+
+      {/* 폼미션 전용 카드 */}
+      {isForm && (
+        <>
+          {/* AI 인증 토글 */}
+          <div className="bg-white rounded-xl p-4 flex items-center justify-between">
+            <span className="text-[14px] font-semibold text-zinc-800">AI 자동 인증</span>
+            <div
+              onClick={() => setUseAI(!useAI)}
+              className={`w-11 h-6 rounded-full relative cursor-pointer transition-colors ${useAI ? 'bg-[#3B3EFF]' : 'bg-zinc-300'}`}
+            >
+              <div className={`absolute top-0.5 w-5 h-5 bg-white rounded-full shadow transition-all ${useAI ? 'left-[22px]' : 'left-0.5'}`} />
+            </div>
+          </div>
+
+          {/* 폼 항목 카드 */}
+          <div className="bg-white rounded-xl p-4 flex flex-col gap-3">
+            <div className="flex items-center justify-between">
+              <label className="text-[13px] font-medium text-zinc-500">폼미션 항목</label>
+              <div className="flex gap-1.5">
+                <button
+                  onClick={() => formItems.length > 1 && setFormItems(formItems.slice(0, -1))}
+                  className="w-7 h-7 rounded-full border border-zinc-300 flex items-center justify-center text-zinc-500 text-base leading-none"
+                >
+                  −
+                </button>
+                <button
+                  onClick={() => setFormItems([...formItems, ''])}
+                  className="w-7 h-7 rounded-full border border-zinc-300 flex items-center justify-center text-zinc-500 text-base leading-none"
+                >
+                  +
+                </button>
+              </div>
+            </div>
+            {formItems.map((item, i) => (
+              <input
+                key={i}
+                className={INPUT_CLS}
+                placeholder={`항목 ${i + 1}`}
+                value={item}
+                onChange={(e) => {
+                  const next = [...formItems];
+                  next[i] = e.target.value;
+                  setFormItems(next);
+                }}
+              />
+            ))}
+          </div>
+
+          {/* 파일 첨부 카드 */}
+          <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3 text-zinc-400 cursor-pointer active:bg-zinc-50">
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66L9.41 17.41a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+            </svg>
+            <span className="text-[14px]">파일 첨부</span>
+          </div>
+        </>
+      )}
+
+      {/* 등록 버튼 */}
+      <button
+        disabled={!canSubmit}
+        className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors mt-2"
+      >
+        미션 등록
+      </button>
+    </div>
+  );
+}

--- a/src/app/[id]/missions/page.tsx
+++ b/src/app/[id]/missions/page.tsx
@@ -6,12 +6,10 @@ import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 type ScopeTab = '전체' | '공통' | '개인';
+type LeaderTab = '공통' | '개인';
 type StatusFilter = '전체' | '진행 중' | '완료';
 
-interface MemberMe {
-  memRole: string;
-  memState: string;
-}
+interface MemberMe { memRole: string; memState: string; }
 
 interface Mission {
   id: string;
@@ -22,27 +20,28 @@ interface Mission {
   status: '가능' | '대기' | '실패' | '완료';
   deadline: string | null;
   kind: '폼미션' | '자유미션';
+  submitCount?: number;
 }
 
 const MOCK_MISSIONS: Mission[] = [
-  { id: '1', scope: '공통', authType: 'AI인증',   title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기',   status: '가능', deadline: '1시간', kind: '폼미션' },
-  { id: '2', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '대기', deadline: '30분',  kind: '자유미션' },
-  { id: '3', scope: '공통', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '가능', deadline: '3일',   kind: '폼미션' },
-  { id: '4', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기',   status: '대기', deadline: null,   kind: '자유미션' },
-  { id: '5', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '실패', deadline: null,   kind: '자유미션' },
-  { id: '6', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '실패', deadline: null,   kind: '폼미션' },
-  { id: '7', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기',   status: '완료', deadline: null,   kind: '자유미션' },
-  { id: '8', scope: '공통', authType: '수동인증', title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기',   status: '완료', deadline: '5일',   kind: '폼미션' },
+  { id: '1', scope: '공통', authType: 'AI인증',   title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기', status: '가능', deadline: '1시간', kind: '폼미션',  submitCount: 3 },
+  { id: '2', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',    status: '대기', deadline: '30분',  kind: '자유미션', submitCount: 1 },
+  { id: '3', scope: '공통', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',    status: '가능', deadline: '3일',   kind: '폼미션',  submitCount: 5 },
+  { id: '4', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기', status: '대기', deadline: null,   kind: '자유미션', submitCount: 2 },
+  { id: '5', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',    status: '실패', deadline: null,   kind: '자유미션', submitCount: 0 },
+  { id: '6', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',    status: '실패', deadline: null,   kind: '폼미션',  submitCount: 0 },
+  { id: '7', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기', status: '완료', deadline: null,   kind: '자유미션', submitCount: 3 },
+  { id: '8', scope: '공통', authType: '수동인증', title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기', status: '완료', deadline: null,  kind: '폼미션',  submitCount: 6 },
 ];
 
-const SCOPE_COLOR: Record<string, string> = {
-  공통: '#FF9E6A',
-  개인: '#E5638C',
-};
-const AUTH_COLOR: Record<string, string> = {
-  'AI인증':  '#3B3EFF',
-  '수동인증': '#31DBD5',
-};
+const MOCK_MEMBERS = [
+  { id: 'M1', name: '김철수', initial: '김' },
+  { id: 'M2', name: '이영희', initial: '이' },
+  { id: 'M3', name: '박지수', initial: '박' },
+];
+
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
 
 function deadlineColor(deadline: string | null): string {
   if (!deadline) return 'text-zinc-400';
@@ -51,87 +50,64 @@ function deadlineColor(deadline: string | null): string {
   return days <= 3 ? 'text-[#f97316]' : 'text-[#3B3EFF]';
 }
 
-function MissionCard({ m }: { m: Mission }) {
-  const isDone = m.status === '실패' || m.status === '완료';
+function Badges({ scope, authType }: { scope: string; authType: string }) {
+  return (
+    <div className="flex gap-1 mb-1">
+      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[scope] }}>{scope}</span>
+      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[authType] }}>{authType}</span>
+    </div>
+  );
+}
 
+function MissionCard({ m, onVerify, onViewPending, onViewCompleted, onViewFailed }: {
+  m: Mission;
+  onVerify?: () => void;
+  onViewPending?: () => void;
+  onViewCompleted?: () => void;
+  onViewFailed?: () => void;
+}) {
+  const isDone = m.status === '실패' || m.status === '완료';
   return (
     <div className="bg-white rounded-lg px-4 py-3 flex items-center gap-3">
       <div className={`w-10 h-10 rounded-full shrink-0 ${isDone ? 'bg-zinc-300' : 'bg-zinc-200'}`} />
-
       <div className="flex-1 min-w-0">
-        <div className="flex gap-1 mb-1">
-          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[m.scope] }}>
-            {m.scope}
-          </span>
-          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[m.authType] }}>
-            {m.authType}
-          </span>
-        </div>
+        <Badges scope={m.scope} authType={m.authType} />
         <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.title}</p>
         <p className="text-[11px] text-zinc-400 mt-1">{m.subtitle}</p>
       </div>
-
       <div className="shrink-0 flex flex-col items-end gap-2">
         {m.status === '가능' && (
           <>
-            <p className="text-[12px]">
-              <span className="text-zinc-800">마감까지 </span>
-              <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
-            </p>
-            <button className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                <path d="M5 12h14M12 5l7 7-7 7" />
-              </svg>
+            <p className="text-[12px]"><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(m.deadline)}>{m.deadline}</span></p>
+            <button onClick={onVerify} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M12 5l7 7-7 7" /></svg>
               인증하기
             </button>
           </>
         )}
         {m.status === '대기' && (
           <>
-            <p className="text-[12px]">
-              {m.deadline ? (
-                <>
-                  <span className="text-zinc-800">마감까지 </span>
-                  <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
-                </>
-              ) : (
-                <span className="text-zinc-400">마감</span>
-              )}
-            </p>
-            <button className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <polyline points="12 6 12 12 16 14" />
-              </svg>
+            <p className="text-[12px]">{m.deadline ? <><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(m.deadline)}>{m.deadline}</span></> : <span className="text-zinc-400">마감</span>}</p>
+            <button onClick={onViewPending} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
               승인 대기
             </button>
           </>
         )}
         {m.status === '실패' && (
           <>
-            <span className="text-[12px] text-zinc-800">마감</span>
-            <button className="text-[12px] font-semibold text-[#3B3EFF] bg-white border border-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                <path d="M18 6L6 18M6 6l12 12" />
-              </svg>
+            <span className="text-[12px] text-zinc-400">마감</span>
+            <button onClick={onViewFailed} className="text-[12px] font-semibold text-[#3B3EFF] bg-white border border-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M18 6L6 18M6 6l12 12" /></svg>
               인증 실패
             </button>
           </>
         )}
         {m.status === '완료' && (
           <>
-            {m.deadline ? (
-              <p className="text-[12px]">
-                <span className="text-zinc-800">마감까지 </span>
-                <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
-              </p>
-            ) : (
-              <span className="text-[10px] text-zinc-400">마감</span>
-            )}
-            <button className="text-[12px] font-medium text-zinc-400 bg-zinc-100 rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                <path d="M5 13l4 4L19 7" />
-              </svg>
+            <span className="text-[12px] text-zinc-400">마감</span>
+            <button onClick={onViewCompleted} className="text-[12px] font-medium text-zinc-400 bg-zinc-100 rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round"><path d="M5 13l4 4L19 7" /></svg>
               인증 완료
             </button>
           </>
@@ -141,12 +117,50 @@ function MissionCard({ m }: { m: Mission }) {
   );
 }
 
+function LeaderCard({ m, onViewSubmissions, showCount = true }: { m: Mission; onViewSubmissions?: () => void; showCount?: boolean }) {
+  return (
+    <div className="bg-white rounded-lg px-4 py-3 flex items-center gap-3">
+      <div className="w-10 h-10 rounded-full bg-zinc-200 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <Badges scope={m.scope} authType={m.authType} />
+        <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.title}</p>
+        <p className="text-[11px] text-zinc-400 mt-1">{m.subtitle}</p>
+      </div>
+      <div className="shrink-0 flex flex-col items-end gap-2">
+        {m.status === '완료' || !m.deadline
+          ? <span className="text-[12px] text-zinc-400">마감</span>
+          : <p className="text-[12px]"><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(m.deadline)}>{m.deadline}</span></p>
+        }
+        <button onClick={onViewSubmissions} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 whitespace-nowrap">
+          제출 확인{showCount ? ` ${m.submitCount ?? 0}` : ''}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function StatusBar({ value, onChange }: { value: StatusFilter; onChange: (v: StatusFilter) => void }) {
+  const filters: StatusFilter[] = ['전체', '진행 중', '완료'];
+  return (
+    <div className="flex items-center justify-center mb-3">
+      {filters.map((f, i) => (
+        <div key={f} className="flex items-center">
+          <button onClick={() => onChange(f)} className={`text-[13px] px-2 ${value === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}>{f}</button>
+          {i < filters.length - 1 && <span className="text-zinc-300 text-[13px]">|</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function MissionsPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const [scopeTab, setScopeTab] = useState<ScopeTab>('전체');
+  const [leaderTab, setLeaderTab] = useState<LeaderTab>('공통');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('전체');
   const [showPopup, setShowPopup] = useState(false);
+  const [devLeader, setDevLeader] = useState<boolean | null>(null);
 
   const { data: myMember } = useQuery<MemberMe>({
     queryKey: ['memberMe', id],
@@ -158,8 +172,9 @@ export default function MissionsPage() {
   });
 
   const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
+  const showLeader = devLeader !== null ? devLeader : isLeader;
 
-  const filtered = MOCK_MISSIONS.filter((m) => {
+  const mFiltered = MOCK_MISSIONS.filter((m) => {
     if (scopeTab === '공통' && m.scope !== '공통') return false;
     if (scopeTab === '개인' && m.scope !== '개인') return false;
     if (statusFilter === '진행 중' && m.status !== '가능' && m.status !== '대기' && m.status !== '실패') return false;
@@ -167,53 +182,106 @@ export default function MissionsPage() {
     return true;
   });
 
+  const applyStatus = (list: Mission[]) => list.filter((m) => {
+    if (statusFilter === '진행 중') return m.status === '가능' || m.status === '대기' || m.status === '실패';
+    if (statusFilter === '완료') return m.status === '완료';
+    return true;
+  });
+
+  const lCommon = applyStatus(MOCK_MISSIONS.filter((m) => m.scope === '공통'));
+  const lPersonal = applyStatus(MOCK_MISSIONS.filter((m) => m.scope === '개인')).slice(0, 3);
+
+  const submissionsHref = (m: Mission) =>
+    `/${id}/missions/${m.id}/submissions?authType=${encodeURIComponent(m.authType)}&scope=${encodeURIComponent(m.scope)}&title=${encodeURIComponent(m.title)}&subtitle=${encodeURIComponent(m.subtitle)}`;
+  const submissionDetailHref = (m: Mission, memberName: string) =>
+    `/${id}/missions/${m.id}/submissions/1?authType=${encodeURIComponent(m.authType)}&scope=${encodeURIComponent(m.scope)}&title=${encodeURIComponent(m.title)}&subtitle=${encodeURIComponent(m.subtitle)}&memberName=${encodeURIComponent(memberName)}&aiResult=`;
+  const verifyHref = (m: Mission) =>
+    `/${id}/missions/${m.id}/verify?authType=${encodeURIComponent(m.authType)}&scope=${encodeURIComponent(m.scope)}&title=${encodeURIComponent(m.title)}&subtitle=${encodeURIComponent(m.subtitle)}`;
+  const pendingHref = (m: Mission, status = '') =>
+    `/${id}/missions/${m.id}/pending?${status ? `status=${status}&` : ''}authType=${encodeURIComponent(m.authType)}&scope=${encodeURIComponent(m.scope)}&title=${encodeURIComponent(m.title)}&subtitle=${encodeURIComponent(m.subtitle)}`;
+
   return (
     <div className="flex flex-col min-h-full">
-      {/* 상단 탭 */}
-      <div className="sticky top-0 z-10 bg-white -mx-4">
-        <div className="flex border-b border-zinc-200">
-          {(['전체', '공통', '개인'] as ScopeTab[]).map((t) => (
-            <button
-              key={t}
-              onClick={() => setScopeTab(t)}
-              className={`flex-1 flex justify-center text-[13px] font-medium transition-colors whitespace-nowrap ${
-                scopeTab === t ? 'text-zinc-900' : 'text-zinc-400'
-              }`}
-            >
-              <span className={`inline-block py-2.5 -mb-px ${scopeTab === t ? 'border-b-2 border-zinc-900' : ''}`}>
-                {t}
-              </span>
-            </button>
-          ))}
-        </div>
+      {/* 개발용 뷰 토글 */}
+      <div className="flex items-center gap-2 -mx-4 px-4 py-1.5 bg-yellow-50 border-b border-yellow-200">
+        <span className="text-[11px] text-yellow-700 font-medium">개발용:</span>
+        <button onClick={() => setDevLeader(false)} className={`text-[11px] px-2.5 py-0.5 rounded-full font-medium transition-colors ${devLeader === false ? 'bg-yellow-400 text-white' : 'text-yellow-600'}`}>멤버</button>
+        <button onClick={() => setDevLeader(true)} className={`text-[11px] px-2.5 py-0.5 rounded-full font-medium transition-colors ${devLeader === true ? 'bg-yellow-400 text-white' : 'text-yellow-600'}`}>팀장</button>
       </div>
 
-      {/* 미션 목록 */}
-      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
-        {/* 서브 필터 */}
-        <div className="flex items-center justify-center mb-3">
-          {(['전체', '진행 중', '완료'] as StatusFilter[]).map((f, i, arr) => (
-            <div key={f} className="flex items-center">
-              <button
-                onClick={() => setStatusFilter(f)}
-                className={`text-[13px] px-2 ${statusFilter === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}
-              >
-                {f}
-              </button>
-              {i < arr.length - 1 && <span className="text-zinc-300 text-[13px]">|</span>}
+      {showLeader ? (
+        <>
+          {/* 팀장: 공통/개인 탭 */}
+          <div className="sticky top-0 z-10 bg-white -mx-4">
+            <div className="flex border-b border-zinc-200">
+              {(['공통', '개인'] as LeaderTab[]).map((t) => (
+                <button key={t} onClick={() => setLeaderTab(t)}
+                  className={`flex-1 flex justify-center text-[13px] font-medium transition-colors ${leaderTab === t ? 'text-zinc-900' : 'text-zinc-400'}`}>
+                  <span className={`inline-block py-2.5 -mb-px ${leaderTab === t ? 'border-b-2 border-zinc-900' : ''}`}>{t}</span>
+                </button>
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
 
-        {filtered.length === 0 ? (
-          <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
-        ) : (
-          filtered.map((m) => <MissionCard key={m.id} m={m} />)
-        )}
-      </div>
+          <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
+            <StatusBar value={statusFilter} onChange={setStatusFilter} />
+
+            {leaderTab === '공통' && (
+              lCommon.length === 0
+                ? <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
+                : lCommon.map((m) => <LeaderCard key={m.id} m={m} onViewSubmissions={() => router.push(submissionsHref(m))} />)
+            )}
+
+            {leaderTab === '개인' && (
+              MOCK_MEMBERS.length === 0
+                ? <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
+                : MOCK_MEMBERS.map((mem) => (
+                  <div key={mem.id} className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2 mt-2">
+                      <div className="w-7 h-7 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
+                        <span className="text-[11px] font-bold text-white">{mem.initial}</span>
+                      </div>
+                      <span className="text-[13px] font-semibold text-zinc-800">{mem.name}</span>
+                    </div>
+                    {lPersonal.map((m) => <LeaderCard key={m.id} m={m} showCount={false} onViewSubmissions={() => router.push(submissionDetailHref(m, mem.name))} />)}
+                  </div>
+                ))
+            )}
+          </div>
+        </>
+      ) : (
+        <>
+          {/* 멤버: 전체/공통/개인 탭 */}
+          <div className="sticky top-0 z-10 bg-white -mx-4">
+            <div className="flex border-b border-zinc-200">
+              {(['전체', '공통', '개인'] as ScopeTab[]).map((t) => (
+                <button key={t} onClick={() => setScopeTab(t)}
+                  className={`flex-1 flex justify-center text-[13px] font-medium transition-colors ${scopeTab === t ? 'text-zinc-900' : 'text-zinc-400'}`}>
+                  <span className={`inline-block py-2.5 -mb-px ${scopeTab === t ? 'border-b-2 border-zinc-900' : ''}`}>{t}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
+            <StatusBar value={statusFilter} onChange={setStatusFilter} />
+            {mFiltered.length === 0
+              ? <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
+              : mFiltered.map((m) => (
+                <MissionCard key={m.id} m={m}
+                  onVerify={() => router.push(verifyHref(m))}
+                  onViewPending={() => router.push(pendingHref(m))}
+                  onViewCompleted={() => router.push(pendingHref(m, 'completed'))}
+                  onViewFailed={() => router.push(pendingHref(m, 'failed'))}
+                />
+              ))
+            }
+          </div>
+        </>
+      )}
 
       {/* 팀장 전용 플로팅 버튼 */}
-      {isLeader && (
+      {showLeader && (
         <button
           onClick={() => setShowPopup(true)}
           className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
@@ -226,28 +294,21 @@ export default function MissionsPage() {
         </button>
       )}
 
-      {/* 미션 종류 선택 팝업 */}
       {showPopup && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setShowPopup(false)} />
-          <div
-            className="fixed z-50 bg-white rounded-xl shadow-xl w-[180px] overflow-hidden border border-zinc-100"
-            style={{ bottom: 'calc(80px + 56px)', right: 'calc(50% - 195px + 16px)' }}
-          >
-            <button
-              onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=free`); }}
-              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors"
-            >
+          <div className="fixed z-50 bg-white rounded-xl shadow-xl w-[180px] overflow-hidden border border-zinc-100"
+            style={{ bottom: 'calc(80px + 56px)', right: 'calc(50% - 195px + 16px)' }}>
+            <button onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=free`); }}
+              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
               </svg>
               <span className="text-[13px] font-semibold text-zinc-900">자유형식 미션</span>
             </button>
             <div className="h-px bg-zinc-100" />
-            <button
-              onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=form`); }}
-              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors"
-            >
+            <button onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=form`); }}
+              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors">
               <div className="relative w-[18px] h-[18px] flex items-center justify-center">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
                   <circle cx="12" cy="8" r="5" />

--- a/src/app/[id]/missions/page.tsx
+++ b/src/app/[id]/missions/page.tsx
@@ -1,102 +1,201 @@
 'use client';
 
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useRouter } from 'next/navigation';
 import api from '@/lib/api';
 
-interface Team {
-  teamId: string;
-  teamName: string;
-  teamImg: string;
-  teamInfo: string;
-  teamCategory: string;
-  currentMember: number;
-  maxMembers: number;
-  code: string;
+type ScopeTab = '전체' | '공통' | '개인';
+type KindFilter = '전체' | '폼미션' | '자유미션';
+
+interface MemberMe {
+  memRole: string;
+  memState: string;
 }
 
-async function fetchGroup(id: string): Promise<Team> {
-  const { data } = await api.get(`/api/teams/${id}`);
-  return data.data;
+interface Mission {
+  id: string;
+  scope: '공통' | '개인';
+  authType: 'AI인증' | '수동인증';
+  title: string;
+  status: '가능' | '대기' | '실패' | '완료';
+  deadline: string | null;
+  kind: '폼미션' | '자유미션';
 }
 
-export default function GroupDetailPage() {
+const MOCK_MISSIONS: Mission[] = [
+  { id: '1', scope: '공통', authType: 'AI인증',   title: '한강, 채식주의자 독서인증!', status: '가능', deadline: '1시간', kind: '폼미션' },
+  { id: '2', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '대기', deadline: '30분',  kind: '자유미션' },
+  { id: '3', scope: '공통', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '가능', deadline: '3일',   kind: '폼미션' },
+  { id: '4', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     status: '대기', deadline: null,   kind: '자유미션' },
+  { id: '5', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '실패', deadline: null,   kind: '자유미션' },
+  { id: '6', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '실패', deadline: null,   kind: '폼미션' },
+  { id: '7', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     status: '완료', deadline: null,   kind: '자유미션' },
+];
+
+const SCOPE_TAG: Record<string, string> = {
+  공통: 'bg-green-400 text-white',
+  개인: 'bg-blue-400 text-white',
+};
+const AUTH_TAG: Record<string, string> = {
+  'AI인증':  'bg-sky-400 text-white',
+  '수동인증': 'bg-violet-400 text-white',
+};
+
+function deadlineColor(deadline: string | null): string {
+  if (!deadline) return 'text-zinc-400';
+  if (deadline.includes('분') || deadline.includes('시간')) return 'text-[#f97316]';
+  const days = Number(deadline.replace(/[^0-9]/g, ''));
+  return days <= 3 ? 'text-[#f97316]' : 'text-[#3B3EFF]';
+}
+
+function Tag({ label, cls }: { label: string; cls: string }) {
+  return (
+    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${cls}`}>{label}</span>
+  );
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  가능: '진행 중',
+  대기: '진행 중',
+  실패: '인증 실패',
+  완료: '인증 완료',
+};
+
+function MissionCard({ m }: { m: Mission }) {
+  const isDone = m.status === '실패' || m.status === '완료';
+  const isActive = m.status === '가능' || m.status === '대기';
+
+  return (
+    <div className="flex items-center gap-3 py-3 border-b border-zinc-100">
+      <div className={`w-10 h-10 rounded-full shrink-0 ${isDone ? 'bg-zinc-300' : 'bg-zinc-200'}`} />
+
+      <div className="flex-1 min-w-0">
+        <span className={`inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full mb-1 ${
+          isActive ? 'bg-[#3B3EFF] text-white' : 'bg-zinc-100 text-zinc-400'
+        }`}>
+          {STATUS_LABEL[m.status]}
+        </span>
+        <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.title}</p>
+        <p className="text-[11px] text-zinc-400 mt-1">{m.scope} · {m.authType}</p>
+      </div>
+
+      <div className="shrink-0 flex flex-col items-end gap-2">
+        {m.status === '가능' && (
+          <>
+            <button className="text-[11px] px-2.5 py-1 rounded-full border border-[#3B3EFF] text-[#3B3EFF] font-medium whitespace-nowrap">
+              인증하기
+            </button>
+            <p className="text-[10px]">
+              <span className="text-zinc-800">마감까지 </span>
+              <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
+            </p>
+          </>
+        )}
+        {m.status === '대기' && (
+          <>
+            <button className="text-[11px] px-2.5 py-1 rounded-full bg-zinc-200 text-zinc-500 font-medium whitespace-nowrap cursor-default">
+              승인 대기
+            </button>
+            <p className="text-[10px]">
+              {m.deadline ? (
+                <>
+                  <span className="text-zinc-800">마감까지 </span>
+                  <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
+                </>
+              ) : (
+                <span className="text-zinc-400">마감</span>
+              )}
+            </p>
+          </>
+        )}
+        {isDone && (
+          <span className="text-[10px] text-zinc-400">마감</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function MissionsPage() {
   const { id } = useParams<{ id: string }>();
-  const router = useRouter();
+  const [scopeTab, setScopeTab] = useState<ScopeTab>('전체');
+  const [kindFilter, setKindFilter] = useState<KindFilter>('전체');
 
-  const { data: group, isLoading, isError } = useQuery({
-    queryKey: ['group', id],
-    queryFn: () => fetchGroup(id),
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
+    queryFn: async () => {
+      const { data } = await api.get(`/api/members/me?teamId=${id}`);
+      return data.data;
+    },
     enabled: !!id,
   });
 
-  if (isLoading) {
-    return (
-      <main className="max-w-2xl mx-auto px-4 py-10 space-y-4">
-        <div className="h-8 w-48 bg-zinc-100 rounded animate-pulse" />
-        <div className="h-4 w-24 bg-zinc-100 rounded animate-pulse" />
-        <div className="h-32 bg-zinc-100 rounded-xl animate-pulse" />
-      </main>
-    );
-  }
+  const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
 
-  if (isError || !group) {
-    return (
-      <main className="max-w-2xl mx-auto px-4 py-10 text-center">
-        <p className="text-zinc-500">모임 정보를 불러오지 못했습니다.</p>
-        <button
-          onClick={() => router.back()}
-          className="mt-4 text-sm text-zinc-400 underline"
-        >
-          돌아가기
-        </button>
-      </main>
-    );
-  }
+  const filtered = MOCK_MISSIONS.filter((m) => {
+    if (scopeTab === '공통' && m.scope !== '공통') return false;
+    if (scopeTab === '개인' && m.scope !== '개인') return false;
+    if (kindFilter !== '전체' && m.kind !== kindFilter) return false;
+    return true;
+  });
 
   return (
-    <main className="max-w-2xl mx-auto px-4 py-10">
-      <button
-        onClick={() => router.back()}
-        className="mb-6 text-sm text-zinc-400 hover:text-zinc-700"
-      >
-        ← 목록으로
-      </button>
+    <div className="-mx-4 -my-5">
+      {/* 상단 탭 + 서브 필터 (같이 sticky) */}
+      <div className="sticky top-0 z-10 bg-white">
+        <div className="flex border-b border-zinc-200">
+          {(['전체', '공통', '개인'] as ScopeTab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setScopeTab(t)}
+              className={`flex-1 flex justify-center text-[13px] font-medium transition-colors whitespace-nowrap ${
+                scopeTab === t ? 'text-zinc-900' : 'text-zinc-400'
+              }`}
+            >
+              <span className={`inline-block py-2.5 -mb-px ${scopeTab === t ? 'border-b-2 border-zinc-900' : ''}`}>
+                {t}
+              </span>
+            </button>
+          ))}
+        </div>
 
-      <div className="flex items-center gap-4 mb-6">
-        {group.teamImg ? (
-          <img src={group.teamImg} alt={group.teamName} className="w-16 h-16 rounded-full object-cover" />
+        <div className="flex items-center justify-center py-2.5 border-b border-zinc-100">
+          {(['전체', '폼미션', '자유미션'] as KindFilter[]).map((f, i, arr) => (
+            <div key={f} className="flex items-center">
+              <button
+                onClick={() => setKindFilter(f)}
+                className={`text-[13px] px-3 ${kindFilter === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}
+              >
+                {f}
+              </button>
+              {i < arr.length - 1 && <span className="text-zinc-200 text-[13px]">|</span>}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 미션 목록 */}
+      <div className="px-4 pt-4 pb-24">
+        {filtered.length === 0 ? (
+          <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
         ) : (
-          <div className="w-16 h-16 rounded-full bg-zinc-200 flex items-center justify-center text-zinc-500 text-xl font-bold">
-            {group.teamName[0]}
-          </div>
+          filtered.map((m) => <MissionCard key={m.id} m={m} />)
         )}
-        <div>
-          <h1 className="text-2xl font-bold">{group.teamName}</h1>
-          <p className="text-sm text-zinc-400">{group.teamCategory}</p>
-        </div>
       </div>
 
-      <div className="border border-zinc-200 rounded-xl p-6 space-y-4">
-        <div>
-          <p className="text-xs text-zinc-400 mb-1">소개</p>
-          <p className="text-sm text-zinc-700 leading-relaxed">{group.teamInfo}</p>
-        </div>
-        <div className="flex gap-6">
-          <div>
-            <p className="text-xs text-zinc-400 mb-1">인원</p>
-            <p className="text-sm font-medium">{group.currentMember} / {group.maxMembers}명</p>
-          </div>
-          <div>
-            <p className="text-xs text-zinc-400 mb-1">초대코드</p>
-            <p className="text-sm font-mono font-medium">{group.code}</p>
-          </div>
-        </div>
-      </div>
-
-      <button className="mt-6 w-full py-3 bg-black text-white rounded-xl text-sm font-medium hover:bg-zinc-800 transition-colors">
-        모임 참가하기
-      </button>
-    </main>
+      {/* 팀장 전용 플로팅 버튼 */}
+      {isLeader && (
+        <button
+          className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
+          style={{ right: 'calc(50% - 195px + 24px)' }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/app/[id]/missions/page.tsx
+++ b/src/app/[id]/missions/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 type ScopeTab = '전체' | '공통' | '개인';
-type KindFilter = '전체' | '폼미션' | '자유미션';
+type StatusFilter = '전체' | '진행 중' | '완료';
 
 interface MemberMe {
   memRole: string;
@@ -18,28 +18,30 @@ interface Mission {
   scope: '공통' | '개인';
   authType: 'AI인증' | '수동인증';
   title: string;
+  subtitle: string;
   status: '가능' | '대기' | '실패' | '완료';
   deadline: string | null;
   kind: '폼미션' | '자유미션';
 }
 
 const MOCK_MISSIONS: Mission[] = [
-  { id: '1', scope: '공통', authType: 'AI인증',   title: '한강, 채식주의자 독서인증!', status: '가능', deadline: '1시간', kind: '폼미션' },
-  { id: '2', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '대기', deadline: '30분',  kind: '자유미션' },
-  { id: '3', scope: '공통', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '가능', deadline: '3일',   kind: '폼미션' },
-  { id: '4', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     status: '대기', deadline: null,   kind: '자유미션' },
-  { id: '5', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '실패', deadline: null,   kind: '자유미션' },
-  { id: '6', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   status: '실패', deadline: null,   kind: '폼미션' },
-  { id: '7', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     status: '완료', deadline: null,   kind: '자유미션' },
+  { id: '1', scope: '공통', authType: 'AI인증',   title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기',   status: '가능', deadline: '1시간', kind: '폼미션' },
+  { id: '2', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '대기', deadline: '30분',  kind: '자유미션' },
+  { id: '3', scope: '공통', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '가능', deadline: '3일',   kind: '폼미션' },
+  { id: '4', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기',   status: '대기', deadline: null,   kind: '자유미션' },
+  { id: '5', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '실패', deadline: null,   kind: '자유미션' },
+  { id: '6', scope: '개인', authType: '수동인증', title: '독서 후 감상문 작성하기!',   subtitle: '감상문 파일 업로드',      status: '실패', deadline: null,   kind: '폼미션' },
+  { id: '7', scope: '개인', authType: 'AI인증',   title: '카프카, 변신 독서인증!',     subtitle: '책 사진 찍고 인증하기',   status: '완료', deadline: null,   kind: '자유미션' },
+  { id: '8', scope: '공통', authType: '수동인증', title: '한강, 채식주의자 독서인증!', subtitle: '책 사진 찍고 인증하기',   status: '완료', deadline: '5일',   kind: '폼미션' },
 ];
 
-const SCOPE_TAG: Record<string, string> = {
-  공통: 'bg-green-400 text-white',
-  개인: 'bg-blue-400 text-white',
+const SCOPE_COLOR: Record<string, string> = {
+  공통: '#FF9E6A',
+  개인: '#E5638C',
 };
-const AUTH_TAG: Record<string, string> = {
-  'AI인증':  'bg-sky-400 text-white',
-  '수동인증': 'bg-violet-400 text-white',
+const AUTH_COLOR: Record<string, string> = {
+  'AI인증':  '#3B3EFF',
+  '수동인증': '#31DBD5',
 };
 
 function deadlineColor(deadline: string | null): string {
@@ -49,55 +51,44 @@ function deadlineColor(deadline: string | null): string {
   return days <= 3 ? 'text-[#f97316]' : 'text-[#3B3EFF]';
 }
 
-function Tag({ label, cls }: { label: string; cls: string }) {
-  return (
-    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${cls}`}>{label}</span>
-  );
-}
-
-const STATUS_LABEL: Record<string, string> = {
-  가능: '진행 중',
-  대기: '진행 중',
-  실패: '인증 실패',
-  완료: '인증 완료',
-};
-
 function MissionCard({ m }: { m: Mission }) {
   const isDone = m.status === '실패' || m.status === '완료';
-  const isActive = m.status === '가능' || m.status === '대기';
 
   return (
-    <div className="flex items-center gap-3 py-3 border-b border-zinc-100">
+    <div className="bg-white rounded-lg px-4 py-3 flex items-center gap-3">
       <div className={`w-10 h-10 rounded-full shrink-0 ${isDone ? 'bg-zinc-300' : 'bg-zinc-200'}`} />
 
       <div className="flex-1 min-w-0">
-        <span className={`inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full mb-1 ${
-          isActive ? 'bg-[#3B3EFF] text-white' : 'bg-zinc-100 text-zinc-400'
-        }`}>
-          {STATUS_LABEL[m.status]}
-        </span>
+        <div className="flex gap-1 mb-1">
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: SCOPE_COLOR[m.scope] }}>
+            {m.scope}
+          </span>
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white" style={{ backgroundColor: AUTH_COLOR[m.authType] }}>
+            {m.authType}
+          </span>
+        </div>
         <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.title}</p>
-        <p className="text-[11px] text-zinc-400 mt-1">{m.scope} · {m.authType}</p>
+        <p className="text-[11px] text-zinc-400 mt-1">{m.subtitle}</p>
       </div>
 
       <div className="shrink-0 flex flex-col items-end gap-2">
         {m.status === '가능' && (
           <>
-            <button className="text-[11px] px-2.5 py-1 rounded-full border border-[#3B3EFF] text-[#3B3EFF] font-medium whitespace-nowrap">
-              인증하기
-            </button>
-            <p className="text-[10px]">
+            <p className="text-[12px]">
               <span className="text-zinc-800">마감까지 </span>
               <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
             </p>
+            <button className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5 12h14M12 5l7 7-7 7" />
+              </svg>
+              인증하기
+            </button>
           </>
         )}
         {m.status === '대기' && (
           <>
-            <button className="text-[11px] px-2.5 py-1 rounded-full bg-zinc-200 text-zinc-500 font-medium whitespace-nowrap cursor-default">
-              승인 대기
-            </button>
-            <p className="text-[10px]">
+            <p className="text-[12px]">
               {m.deadline ? (
                 <>
                   <span className="text-zinc-800">마감까지 </span>
@@ -107,10 +98,43 @@ function MissionCard({ m }: { m: Mission }) {
                 <span className="text-zinc-400">마감</span>
               )}
             </p>
+            <button className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <polyline points="12 6 12 12 16 14" />
+              </svg>
+              승인 대기
+            </button>
           </>
         )}
-        {isDone && (
-          <span className="text-[10px] text-zinc-400">마감</span>
+        {m.status === '실패' && (
+          <>
+            <span className="text-[12px] text-zinc-800">마감</span>
+            <button className="text-[12px] font-semibold text-[#3B3EFF] bg-white border border-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6L6 18M6 6l12 12" />
+              </svg>
+              인증 실패
+            </button>
+          </>
+        )}
+        {m.status === '완료' && (
+          <>
+            {m.deadline ? (
+              <p className="text-[12px]">
+                <span className="text-zinc-800">마감까지 </span>
+                <span className={deadlineColor(m.deadline)}>{m.deadline}</span>
+              </p>
+            ) : (
+              <span className="text-[10px] text-zinc-400">마감</span>
+            )}
+            <button className="text-[12px] font-medium text-zinc-400 bg-zinc-100 rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap cursor-default">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              인증 완료
+            </button>
+          </>
         )}
       </div>
     </div>
@@ -119,8 +143,10 @@ function MissionCard({ m }: { m: Mission }) {
 
 export default function MissionsPage() {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
   const [scopeTab, setScopeTab] = useState<ScopeTab>('전체');
-  const [kindFilter, setKindFilter] = useState<KindFilter>('전체');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('전체');
+  const [showPopup, setShowPopup] = useState(false);
 
   const { data: myMember } = useQuery<MemberMe>({
     queryKey: ['memberMe', id],
@@ -136,14 +162,15 @@ export default function MissionsPage() {
   const filtered = MOCK_MISSIONS.filter((m) => {
     if (scopeTab === '공통' && m.scope !== '공통') return false;
     if (scopeTab === '개인' && m.scope !== '개인') return false;
-    if (kindFilter !== '전체' && m.kind !== kindFilter) return false;
+    if (statusFilter === '진행 중' && m.status !== '가능' && m.status !== '대기' && m.status !== '실패') return false;
+    if (statusFilter === '완료' && m.status !== '완료') return false;
     return true;
   });
 
   return (
-    <div className="-mx-4 -my-5">
-      {/* 상단 탭 + 서브 필터 (같이 sticky) */}
-      <div className="sticky top-0 z-10 bg-white">
+    <div className="flex flex-col min-h-full">
+      {/* 상단 탭 */}
+      <div className="sticky top-0 z-10 bg-white -mx-4">
         <div className="flex border-b border-zinc-200">
           {(['전체', '공통', '개인'] as ScopeTab[]).map((t) => (
             <button
@@ -159,24 +186,25 @@ export default function MissionsPage() {
             </button>
           ))}
         </div>
-
-        <div className="flex items-center justify-center py-2.5 border-b border-zinc-100">
-          {(['전체', '폼미션', '자유미션'] as KindFilter[]).map((f, i, arr) => (
-            <div key={f} className="flex items-center">
-              <button
-                onClick={() => setKindFilter(f)}
-                className={`text-[13px] px-3 ${kindFilter === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}
-              >
-                {f}
-              </button>
-              {i < arr.length - 1 && <span className="text-zinc-200 text-[13px]">|</span>}
-            </div>
-          ))}
-        </div>
       </div>
 
       {/* 미션 목록 */}
-      <div className="px-4 pt-4 pb-24">
+      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
+        {/* 서브 필터 */}
+        <div className="flex items-center justify-center mb-3">
+          {(['전체', '진행 중', '완료'] as StatusFilter[]).map((f, i, arr) => (
+            <div key={f} className="flex items-center">
+              <button
+                onClick={() => setStatusFilter(f)}
+                className={`text-[13px] px-2 ${statusFilter === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}
+              >
+                {f}
+              </button>
+              {i < arr.length - 1 && <span className="text-zinc-300 text-[13px]">|</span>}
+            </div>
+          ))}
+        </div>
+
         {filtered.length === 0 ? (
           <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
         ) : (
@@ -187,6 +215,7 @@ export default function MissionsPage() {
       {/* 팀장 전용 플로팅 버튼 */}
       {isLeader && (
         <button
+          onClick={() => setShowPopup(true)}
           className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
           style={{ right: 'calc(50% - 195px + 24px)' }}
         >
@@ -195,6 +224,41 @@ export default function MissionsPage() {
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </button>
+      )}
+
+      {/* 미션 종류 선택 팝업 */}
+      {showPopup && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setShowPopup(false)} />
+          <div
+            className="fixed z-50 bg-white rounded-xl shadow-xl w-[180px] overflow-hidden border border-zinc-100"
+            style={{ bottom: 'calc(80px + 56px)', right: 'calc(50% - 195px + 16px)' }}
+          >
+            <button
+              onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=free`); }}
+              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              </svg>
+              <span className="text-[13px] font-semibold text-zinc-900">자유형식 미션</span>
+            </button>
+            <div className="h-px bg-zinc-100" />
+            <button
+              onClick={() => { setShowPopup(false); router.push(`/${id}/missions/new?kind=form`); }}
+              className="w-full flex items-center gap-2.5 px-4 py-3 active:bg-zinc-50 transition-colors"
+            >
+              <div className="relative w-[18px] h-[18px] flex items-center justify-center">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="8" r="5" />
+                  <path d="M3 21v-1a9 9 0 0 1 9-9h0a9 9 0 0 1 9 9v1" />
+                </svg>
+                <span className="absolute bottom-0 right-0 text-[6px] font-black leading-none bg-white text-zinc-800">AI</span>
+              </div>
+              <span className="text-[13px] font-semibold text-zinc-900">자동 폼 미션</span>
+            </button>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- 팀장 뷰: 공통/개인 탭, 제출 확인 버튼(공통은 목록, 개인은 상세로 바로 이동), 개발용 토글
- 멤버 뷰: 전체/공통/개인 탭 + 진행중/완료 필터, 인증하기/승인대기/인증실패/인증완료 상태 버튼
- 인증 제출 페이지: AI인증(사진 최대 3장), 수동인증(텍스트+파일)
- 제출 현황 페이지: 미션 정보 카드, 대기/완료/전체 통계, authType별 필터링
- 제출 상세 페이지: 승인·거절 처리, 거절 사유 입력 팝업
- 인증 상태 페이지: 대기/완료/실패 상태별 UI, 실패 시 다시 제출하기
- 미션 생성: 개인 선택 시 멤버 리스트 표시

## Test plan
- [ ] 멤버 뷰에서 탭/필터 동작 확인
- [ ] 팀장 뷰 토글 전환 확인
- [ ] 인증하기 → AI/수동 페이지 분기 확인
- [ ] 제출 확인 → 공통(목록), 개인(상세 바로) 확인
- [ ] 승인/거절 버튼 및 거절 사유 팝업 확인
- [ ] 미션 생성 개인 선택 시 멤버 리스트 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)