### PR TITLE
feat: auth 페이지 UI 개선

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, type FormEvent } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
 import { useAuthStore } from '@/store/authStore';
@@ -15,7 +15,7 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  async function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: { preventDefault: () => void }) {
     e.preventDefault();
     setError('');
     setLoading(true);
@@ -35,9 +35,12 @@ export default function LoginPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-xl font-bold text-zinc-800 mb-1">로그인</h1>
-      <p className="text-sm text-zinc-500 mb-6">이메일과 비밀번호를 입력해주세요.</p>
+    <div className="flex flex-col gap-8">
+      {/* 타이틀 */}
+      <div>
+        <h1 className="text-[22px] font-bold text-zinc-900 mb-1">로그인</h1>
+        <p className="text-[14px] text-zinc-400">이메일과 비밀번호를 입력해주세요.</p>
+      </div>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
         <input
@@ -46,7 +49,7 @@ export default function LoginPage() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
+          className="w-full border border-zinc-200 rounded-xl px-4 py-3 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-zinc-50"
         />
         <input
           type="password"
@@ -54,39 +57,51 @@ export default function LoginPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
+          className="w-full border border-zinc-200 rounded-xl px-4 py-3 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-zinc-50"
         />
 
-        <div className="flex items-center justify-between text-xs text-zinc-500 mt-1">
-          <label className="flex items-center gap-1.5 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={autoLogin}
-              onChange={(e) => setAutoLogin(e.target.checked)}
-              className="accent-zinc-600"
-            />
-            자동 로그인
+        <div className="flex items-center justify-between mt-1">
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <div
+              onClick={() => setAutoLogin(!autoLogin)}
+              className={`w-4 h-4 rounded border flex items-center justify-center transition-colors ${autoLogin ? 'bg-[#3B3EFF] border-[#3B3EFF]' : 'border-zinc-300 bg-white'}`}
+            >
+              {autoLogin && (
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </div>
+            <span className="text-[13px] text-zinc-500">자동 로그인</span>
           </label>
           <div className="flex gap-3">
-            <Link href="/auth/find-email" className="hover:text-zinc-700">아이디 찾기</Link>
-            <Link href="/auth/reset-password" className="hover:text-zinc-700">비밀번호 재설정</Link>
+            <Link href="/auth/find-email" className="text-[12px] text-zinc-400 hover:text-zinc-600 transition-colors">아이디 찾기</Link>
+            <span className="text-zinc-200 text-[12px]">|</span>
+            <Link href="/auth/reset-password" className="text-[12px] text-zinc-400 hover:text-zinc-600 transition-colors">비밀번호 재설정</Link>
           </div>
         </div>
 
-        {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+        {error && (
+          <div className="flex items-center gap-1.5 bg-red-50 rounded-lg px-3 py-2">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p className="text-[12px] text-red-500">{error}</p>
+          </div>
+        )}
 
         <button
           type="submit"
-          disabled={loading}
-          className="w-full bg-zinc-400 hover:bg-zinc-500 text-white py-2.5 rounded text-sm font-medium mt-2 disabled:opacity-60 transition-colors"
+          disabled={loading || !email || !password}
+          className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold mt-2 disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors"
         >
           {loading ? '로그인 중...' : '로그인'}
         </button>
       </form>
 
-      <p className="text-xs text-center text-zinc-500 mt-6">
+      <p className="text-[13px] text-center text-zinc-400">
         크루와이즈가 처음이신가요?{' '}
-        <Link href="/auth/signup" className="font-medium text-zinc-700 underline">
+        <Link href="/auth/signup" className="font-semibold text-[#3B3EFF]">
           회원가입
         </Link>
       </p>

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -5,6 +5,19 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
 
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-xl px-4 py-3 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-zinc-50';
+
+function ErrorBox({ msg }: { msg: string }) {
+  return (
+    <div className="flex items-center gap-1.5 bg-red-50 rounded-lg px-3 py-2">
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      <p className="text-[12px] text-red-500">{msg}</p>
+    </div>
+  );
+}
+
 export default function ResetPasswordPage() {
   const router = useRouter();
   const [step, setStep] = useState<'verify' | 'reset'>('verify');
@@ -32,10 +45,7 @@ export default function ResetPasswordPage() {
   async function handleReset(e: { preventDefault(): void }) {
     e.preventDefault();
     setError('');
-    if (password !== passwordConfirm) {
-      setError('비밀번호가 일치하지 않습니다.');
-      return;
-    }
+    if (password !== passwordConfirm) { setError('비밀번호가 일치하지 않습니다.'); return; }
     setLoading(true);
     try {
       await api.post('/api/auth/reset-password', { email, phone, newPassword: password });
@@ -48,79 +58,53 @@ export default function ResetPasswordPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-xl font-bold text-zinc-800 mb-1">비밀번호 재설정</h1>
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="text-[22px] font-bold text-zinc-900 mb-1">비밀번호 재설정</h1>
+        <p className="text-[14px] text-zinc-400">
+          {step === 'verify' ? '이메일과 전화번호를 입력해주세요.' : '새 비밀번호를 입력해주세요.'}
+        </p>
+      </div>
+
+      {/* 단계 표시 */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center justify-center w-6 h-6 rounded-full bg-[#3B3EFF] text-white text-[11px] font-bold shrink-0">1</div>
+        <span className={`text-[13px] font-medium ${step === 'verify' ? 'text-zinc-900' : 'text-zinc-400'}`}>본인 확인</span>
+        <div className="flex-1 h-px bg-zinc-200 mx-1" />
+        <div className={`flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-bold shrink-0 ${step === 'reset' ? 'bg-[#3B3EFF] text-white' : 'bg-zinc-200 text-zinc-400'}`}>2</div>
+        <span className={`text-[13px] font-medium ${step === 'reset' ? 'text-zinc-900' : 'text-zinc-400'}`}>비밀번호 변경</span>
+      </div>
 
       {step === 'verify' ? (
-        <>
-          <p className="text-sm text-zinc-500 mb-6">이메일과 전화번호를 입력해주세요.</p>
-          <form onSubmit={handleVerify} className="flex flex-col gap-3">
-            <input
-              type="email"
-              placeholder="이메일"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-            />
-            <input
-              type="tel"
-              placeholder="전화번호 (숫자만)"
-              value={phone}
-              onChange={(e) => setPhone(e.target.value)}
-              required
-              className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-            />
-            {error && <p className="text-xs text-red-500">{error}</p>}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-[#3B3EFF] text-white py-2.5 rounded text-sm font-medium mt-1 disabled:opacity-60 transition-opacity"
-            >
-              {loading ? '확인 중...' : '확인'}
-            </button>
-          </form>
-        </>
+        <form onSubmit={handleVerify} className="flex flex-col gap-3">
+          <input type="email" placeholder="이메일" value={email} onChange={(e) => setEmail(e.target.value)} required className={INPUT_CLS} />
+          <input type="tel" placeholder="전화번호 (숫자만)" value={phone} onChange={(e) => setPhone(e.target.value)} required className={INPUT_CLS} />
+          {error && <ErrorBox msg={error} />}
+          <button type="submit" disabled={loading || !email || !phone}
+            className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold mt-1 disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors">
+            {loading ? '확인 중...' : '확인'}
+          </button>
+        </form>
       ) : (
-        <>
-          <p className="text-sm text-zinc-500 mb-6">새 비밀번호를 입력해주세요.</p>
-          <form onSubmit={handleReset} className="flex flex-col gap-3">
-            <input
-              type="password"
-              placeholder="새 비밀번호"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-            />
-            <input
-              type="password"
-              placeholder="비밀번호 확인"
-              value={passwordConfirm}
-              onChange={(e) => setPasswordConfirm(e.target.value)}
-              required
-              className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-            />
-            {error && <p className="text-xs text-red-500">{error}</p>}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-[#3B3EFF] text-white py-2.5 rounded text-sm font-medium mt-1 disabled:opacity-60 transition-opacity"
-            >
-              {loading ? '처리 중...' : '변경하기'}
-            </button>
-          </form>
-        </>
+        <form onSubmit={handleReset} className="flex flex-col gap-3">
+          <input type="password" placeholder="새 비밀번호" value={password} onChange={(e) => setPassword(e.target.value)} required className={INPUT_CLS} />
+          <input type="password" placeholder="비밀번호 확인" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} required className={INPUT_CLS} />
+          {error && <ErrorBox msg={error} />}
+          <button type="submit" disabled={loading || !password || !passwordConfirm}
+            className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold mt-1 disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors">
+            {loading ? '처리 중...' : '변경하기'}
+          </button>
+        </form>
       )}
 
-      <div className="flex flex-col items-center gap-1 mt-6 text-xs text-zinc-500">
-        <p>
+      <div className="flex flex-col items-center gap-1.5">
+        <p className="text-[13px] text-zinc-400">
           크루와이즈가 처음이신가요?{' '}
-          <Link href="/auth/signup" className="font-medium text-zinc-700 underline">회원가입</Link>
+          <Link href="/auth/signup" className="font-semibold text-[#3B3EFF]">회원가입</Link>
         </p>
-        <p>
+        <p className="text-[13px] text-zinc-400">
           이미 크루와이즈 회원이신가요?{' '}
-          <Link href="/auth/login" className="font-medium text-zinc-700 underline">로그인</Link>
+          <Link href="/auth/login" className="font-semibold text-[#3B3EFF]">로그인</Link>
         </p>
       </div>
     </div>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -6,12 +6,29 @@ import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
 
 const TERMS = [
-  { id: 'terms', label: '[필수] 이용약관 및 개인정보 수집·이용 동의, 개인정보 제3자 제공에 동의합니다', required: true },
-  { id: 'privacy', label: '[필수] 광고성 정보 및 개인정보 수집 동의', required: true },
-  { id: 'marketing', label: '[선택] 마케팅 정보 수신 동의', required: false },
+  { id: 'terms',     label: '[필수] 이용약관 및 개인정보 수집·이용 동의',  required: true  },
+  { id: 'privacy',   label: '[필수] 광고성 정보 및 개인정보 수집 동의',     required: true  },
+  { id: 'marketing', label: '[선택] 마케팅 정보 수신 동의',                required: false },
 ];
 
 type TermId = 'terms' | 'privacy' | 'marketing';
+
+const INPUT_CLS = 'w-full border border-zinc-200 rounded-xl px-4 py-3 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-zinc-50';
+
+function Checkbox({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <div
+      onClick={() => onChange(!checked)}
+      className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 cursor-pointer transition-colors ${checked ? 'bg-[#3B3EFF] border-[#3B3EFF]' : 'border-zinc-300 bg-white'}`}
+    >
+      {checked && (
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M5 13l4 4L19 7" />
+        </svg>
+      )}
+    </div>
+  );
+}
 
 export default function SignupPage() {
   const router = useRouter();
@@ -19,13 +36,14 @@ export default function SignupPage() {
   const [emailChecked, setEmailChecked] = useState(false);
   const [checked, setChecked] = useState<Record<TermId, boolean>>({ terms: false, privacy: false, marketing: false });
   const [allChecked, setAllChecked] = useState(false);
+  const [emailError, setEmailError] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
   function handleChange(e: { target: { name: string; value: string } }) {
     const { name, value } = e.target;
     setForm((prev) => ({ ...prev, [name]: value }));
-    if (name === 'email') setEmailChecked(false);
+    if (name === 'email') { setEmailChecked(false); setEmailError(''); }
   }
 
   function handleTermChange(id: TermId, val: boolean) {
@@ -46,7 +64,7 @@ export default function SignupPage() {
       await api.post('/api/auth/check-email', { email: form.email });
       setEmailChecked(true);
     } catch {
-      setError('이미 사용 중인 이메일입니다.');
+      setEmailError('이미 사용 중인 이메일입니다.');
     }
   }
 
@@ -73,10 +91,14 @@ export default function SignupPage() {
   }
 
   return (
-    <div>
-      <h1 className="text-xl font-bold text-zinc-800 mb-6">회원가입</h1>
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="text-[22px] font-bold text-zinc-900 mb-1">회원가입</h1>
+        <p className="text-[14px] text-zinc-400">크루와이즈에 오신 걸 환영해요!</p>
+      </div>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        {/* 이메일 */}
         <div className="flex gap-2">
           <input
             type="email"
@@ -85,99 +107,74 @@ export default function SignupPage() {
             value={form.email}
             onChange={handleChange}
             required
-            className="flex-1 border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
+            className="flex-1 border border-zinc-200 rounded-xl px-4 py-3 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-zinc-50"
           />
           <button
             type="button"
             onClick={handleEmailCheck}
-            className="shrink-0 bg-zinc-200 hover:bg-zinc-300 text-zinc-700 text-xs px-3 rounded transition-colors"
+            className={`shrink-0 px-4 rounded-xl text-[13px] font-semibold transition-colors ${emailChecked ? 'bg-emerald-50 text-emerald-600' : 'bg-[#EBEBFF] text-[#3B3EFF]'}`}
           >
-            중복 확인
+            {emailChecked ? '확인완료' : '중복확인'}
           </button>
         </div>
-        {emailChecked && (
-          <p className="text-xs text-green-600 -mt-1">사용 가능한 이메일입니다.</p>
+
+        {emailError && (
+          <div className="flex items-center gap-1.5 bg-red-50 rounded-lg px-3 py-2 -mt-1">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p className="text-[12px] text-red-500">{emailError}</p>
+          </div>
         )}
 
-        <input
-          type="password"
-          name="password"
-          placeholder="비밀번호"
-          value={form.password}
-          onChange={handleChange}
-          required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-        />
-        <input
-          type="password"
-          name="passwordConfirm"
-          placeholder="비밀번호 확인"
-          value={form.passwordConfirm}
-          onChange={handleChange}
-          required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-        />
-        <input
-          type="text"
-          name="name"
-          placeholder="이름"
-          value={form.name}
-          onChange={handleChange}
-          required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-        />
-        <input
-          type="tel"
-          name="phone"
-          placeholder="전화번호"
-          value={form.phone}
-          onChange={handleChange}
-          required
-          className="w-full border border-zinc-300 rounded px-3 py-2.5 text-sm placeholder:text-zinc-400 focus:outline-none focus:border-zinc-500"
-        />
+        {/* 비밀번호 */}
+        <input type="password" name="password"        placeholder="비밀번호"      value={form.password}        onChange={handleChange} required className={INPUT_CLS} />
+        <input type="password" name="passwordConfirm" placeholder="비밀번호 확인" value={form.passwordConfirm} onChange={handleChange} required className={INPUT_CLS} />
 
-        <div className="border border-zinc-200 rounded p-3 mt-1 flex flex-col gap-2">
-          <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-zinc-700 select-none">
-            <input
-              type="checkbox"
-              checked={allChecked}
-              onChange={(e) => handleAllChange(e.target.checked)}
-              className="accent-zinc-600"
-            />
-            전체 동의
+        {/* 이름 / 전화번호 */}
+        <input type="text" name="name"  placeholder="이름"   value={form.name}  onChange={handleChange} required className={INPUT_CLS} />
+        <input type="tel"  name="phone" placeholder="전화번호" value={form.phone} onChange={handleChange} required className={INPUT_CLS} />
+
+        {/* 약관 */}
+        <div className="border border-zinc-200 rounded-xl p-4 flex flex-col gap-3 mt-1 bg-zinc-50">
+          <label className="flex items-center gap-2.5 cursor-pointer select-none">
+            <Checkbox checked={allChecked} onChange={handleAllChange} />
+            <span className="text-[14px] font-semibold text-zinc-800">전체 동의</span>
           </label>
-          <div className="border-t border-zinc-100 pt-2 flex flex-col gap-2">
+          <div className="border-t border-zinc-200 pt-3 flex flex-col gap-2.5">
             {TERMS.map((term) => (
-              <div key={term.id} className="flex items-start justify-between gap-2">
-                <label className="flex items-start gap-2 cursor-pointer text-xs text-zinc-600 flex-1 select-none">
-                  <input
-                    type="checkbox"
-                    checked={checked[term.id as TermId]}
-                    onChange={(e) => handleTermChange(term.id as TermId, e.target.checked)}
-                    className="mt-0.5 accent-zinc-600 shrink-0"
-                  />
-                  {term.label}
+              <div key={term.id} className="flex items-center justify-between gap-2">
+                <label className="flex items-center gap-2.5 cursor-pointer select-none flex-1">
+                  <Checkbox checked={checked[term.id as TermId]} onChange={(v) => handleTermChange(term.id as TermId, v)} />
+                  <span className="text-[12px] text-zinc-500">{term.label}</span>
                 </label>
-                <button type="button" className="text-xs text-zinc-400 hover:text-zinc-600 shrink-0">보기</button>
+                <button type="button" className="text-[11px] text-zinc-400 underline shrink-0">보기</button>
               </div>
             ))}
           </div>
         </div>
 
-        {error && <p className="text-xs text-red-500">{error}</p>}
+        {error && (
+          <div className="flex items-center gap-1.5 bg-red-50 rounded-lg px-3 py-2">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="12" y1="8" x2="12" y2="12" /><line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <p className="text-[12px] text-red-500">{error}</p>
+          </div>
+        )}
 
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-zinc-400 hover:bg-zinc-500 text-white py-2.5 rounded text-sm font-medium mt-1 disabled:opacity-60 transition-colors"
+          className="w-full h-[52px] bg-[#3B3EFF] text-white rounded-2xl text-[15px] font-bold mt-1 disabled:bg-zinc-300 disabled:text-zinc-500 transition-colors"
         >
           {loading ? '처리 중...' : '회원가입'}
         </button>
       </form>
 
-      <p className="text-xs text-center text-zinc-500 mt-6">
+      <p className="text-[13px] text-center text-zinc-400">
         이미 크루와이즈 회원이신가요?{' '}
-        <Link href="/auth/login" className="font-medium text-zinc-700 underline">
+        <Link href="/auth/login" className="font-semibold text-[#3B3EFF]">
           로그인
         </Link>
       </p>


### PR DESCRIPTION
## Summary
- 로그인, 회원가입, 비밀번호 재설정 페이지 UI를 앱 디자인에 맞게 통일
- 입력창: `border-zinc-200`, `rounded-xl`, `bg-zinc-50`, `focus:border-[#3B3EFF]`
- 버튼: `h-[52px]`, `bg-[#3B3EFF]`, `rounded-2xl`, `disabled:bg-zinc-300`
- 에러 메시지: 빨간 배경 박스 + SVG 아이콘
- 회원가입: 이메일 중복 확인 버튼, 약관 체크박스, 이메일 에러를 입력칸 바로 아래 표시
- 비밀번호 재설정: 2단계 플로우 (본인 확인 → 비밀번호 변경) + 단계 인디케이터

## Test plan
- [ ] 로그인 페이지 UI 확인
- [ ] 회원가입 - 이메일 중복확인, 약관 동의, 에러 메시지 위치 확인
- [ ] 비밀번호 재설정 - 1단계 → 2단계 전환 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)