### PR TITLE
feat: 회의록 생성 시 음성 파일 실제 업로드 연동

### DIFF
--- a/src/app/[id]/minutes/create/page.tsx
+++ b/src/app/[id]/minutes/create/page.tsx
@@ -161,34 +161,50 @@ export default function MinutesCreatePage() {
   }, [setPageHeader]);
 
   const createMutation = useMutation({
-    mutationFn: (recFileKey: string) =>
-      api.post('/api/meeting-records', { teamId: id, recFileKey }),
+    mutationFn: ({ recFileKey, meetingTitle }: { recFileKey: string; meetingTitle: string }) =>
+      api.post('/api/meeting-records', { teamId: id, recFileKey, meetingTitle }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['meeting-records', id] });
       router.back();
-    },
-    onError: () => {
-      setCurrentStep(0);
     },
   });
 
   useEffect(() => {
     if (!generating) return;
+    let cancelled = false;
     const interval = setInterval(() => {
       setDots((d) => (d.length >= 3 ? '' : d + '·'));
     }, 400);
-    const t1 = setTimeout(() => setCurrentStep(1), 600);
-    const t2 = setTimeout(() => setCurrentStep(2), 1500);
-    const t3 = setTimeout(() => {
-      setCurrentStep(3);
-      const fileKey = files[0]?.file.name ?? 'recording';
-      createMutation.mutate(fileKey);
-    }, 2500);
+
+    async function run() {
+      try {
+        const formData = new FormData();
+        formData.append('file', files[0].file);
+        const { data: uploadRes } = await api.post('/api/files/upload', formData, {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        });
+        if (cancelled) return;
+        const fileUrl = uploadRes.data as string;
+
+        setCurrentStep(1);
+        await new Promise((r) => setTimeout(r, 900));
+        if (cancelled) return;
+
+        setCurrentStep(2);
+        await new Promise((r) => setTimeout(r, 1000));
+        if (cancelled) return;
+
+        setCurrentStep(3);
+        createMutation.mutate({ recFileKey: fileUrl, meetingTitle: title });
+      } catch {
+        if (!cancelled) setGenerating(false);
+      }
+    }
+
+    run();
     return () => {
+      cancelled = true;
       clearInterval(interval);
-      clearTimeout(t1);
-      clearTimeout(t2);
-      clearTimeout(t3);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generating]);


### PR DESCRIPTION
## Summary
- 회의록 생성 페이지에서 음성 파일을 `/api/files/upload`에 실제 업로드 후 URL 저장
- 업로드 → 변환 → 요약 → 저장 단계별 진행 UI 유지
- 백엔드 meeting-records 도메인 추가 (MEETING_RECORD 테이블)

## Test plan
- [ ] 회의록 생성 > 음성 파일 선택 후 AI 요약 생성 버튼 클릭 시 파일 서버 업로드 확인
- [ ] 생성 완료 후 회의록 목록에 표시 확인
- [ ] 회의록 상세 > 정보 탭에서 음성파일 URL 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)