### PR TITLE
feat: 마이페이지 프로필 기능 완성

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import Link from 'next/link';
 import { useState } from 'react';
@@ -44,9 +44,10 @@ interface MenuPopupProps {
   name: string;
   email: string;
   initial: string;
+  profileImg: string | null;
 }
 
-function MenuPopup({ onClose, name, email, initial }: MenuPopupProps) {
+function MenuPopup({ onClose, name, email, initial, profileImg }: MenuPopupProps) {
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -59,8 +60,12 @@ function MenuPopup({ onClose, name, email, initial }: MenuPopupProps) {
       <div className="absolute top-[52px] right-4 z-50 bg-white rounded-xl shadow-xl w-[190px] overflow-hidden border border-zinc-100">
         {/* 프로필 */}
         <div className="flex items-center gap-2.5 px-3.5 py-3 border-b border-zinc-100">
-          <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
-            <span className="text-[13px] font-bold text-white">{initial}</span>
+          <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0 overflow-hidden">
+            {profileImg ? (
+              <img src={profileImg} alt="profile" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-[13px] font-bold text-white">{initial}</span>
+            )}
           </div>
           <div className="min-w-0">
             <p className="text-[13px] font-bold text-zinc-900 truncate">{name}</p>
@@ -514,6 +519,17 @@ export default function MainPage() {
   const initial = name[0] || '?';
   const id = user?.userId || '';
 
+  const { data: profileImages = [] } = useQuery<{ imgId: number; imgFileKey: string }[]>({
+    queryKey: ['me', 'images'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/users/me/images');
+      return data.data;
+    },
+    enabled: !!id,
+  });
+  const realProfileImages = profileImages.filter((img) => img.imgFileKey !== 'default');
+  const profileImg = realProfileImages[realProfileImages.length - 1]?.imgFileKey ?? null;
+
   const { data: myTeams} = useQuery({
     queryKey: ['myTeams'],
     queryFn: async () => {
@@ -553,7 +569,7 @@ export default function MainPage() {
 
   return (
     <div className="w-full h-screen bg-white flex flex-col max-w-[390px] mx-auto shadow-sm relative">
-      {menuOpen && <MenuPopup onClose={() => setMenuOpen(false)} name={name} email={email} initial={initial} />}
+      {menuOpen && <MenuPopup onClose={() => setMenuOpen(false)} name={name} email={email} initial={initial} profileImg={profileImg} />}
       {joinModalOpen && (
         <JoinByCodeModal
           onClose={() => setJoinModalOpen(false)}
@@ -564,8 +580,12 @@ export default function MainPage() {
       <header className="flex items-center justify-between px-4 h-[52px] shrink-0 border-b border-zinc-100 bg-white">
         <span className="text-[17px] font-bold tracking-tight">CrewWise</span>
         <div className="flex items-center gap-2">
-          <button onClick={() => setMenuOpen(true)} className="w-7 h-7 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
-            <span className="text-[13px] font-bold text-white">{initial}</span>
+          <button onClick={() => setMenuOpen(true)} className="w-7 h-7 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0 overflow-hidden">
+            {profileImg ? (
+              <img src={profileImg} alt="profile" className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-[13px] font-bold text-white">{initial}</span>
+            )}
           </button>
         </div>
       </header>

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -43,18 +43,30 @@ export default function MyPageEditPage() {
   const [name, setName] = useState('');
   const [tel, setTel] = useState('');
 
+  const formatTel = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, 11);
+    if (digits.length < 4) return digits;
+    if (digits.length < 8) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+    return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  };
+
   const initialized = useRef(false);
   if (user && !initialized.current) {
-    setTel(user.userTel ?? '');
+    setName(user.userName ?? '');
+    setTel(formatTel(user.userTel ?? ''));
     initialized.current = true;
   }
 
   const { mutate: save, isPending } = useMutation({
     mutationFn: () =>
-      api.patch('/api/auth/me', { userName: name, userTel: tel }),
+      api.patch('/api/users/me', { userName: name, userTel: tel.replace(/-/g, '') }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['me'] });
       router.push('/mypage');
+    },
+    onError: (err: unknown) => {
+      console.error('프로필 저장 실패', err);
+      alert('저장에 실패했습니다. 다시 시도해 주세요.');
     },
   });
 
@@ -137,7 +149,7 @@ export default function MyPageEditPage() {
               <input
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                placeholder="홍길동"
+                placeholder=""
                 className="flex-1 text-[13px] text-zinc-800 border-b border-zinc-200 outline-none py-0.5 bg-transparent"
               />
             </div>
@@ -146,7 +158,7 @@ export default function MyPageEditPage() {
               <span className="text-[13px] text-zinc-400 w-16 shrink-0">전화번호</span>
               <input
                 value={tel}
-                onChange={(e) => setTel(e.target.value)}
+                onChange={(e) => setTel(formatTel(e.target.value))}
                 placeholder="010-0000-0000"
                 className="flex-1 text-[13px] text-zinc-800 border-b border-zinc-200 outline-none py-0.5 bg-transparent"
               />

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -12,11 +12,17 @@ interface UserResponse {
   userTel: string;
 }
 
+interface UserImgResponse {
+  imgId: number;
+  imgFileKey: string;
+}
+
 export default function MyPageEditPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const fileRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
 
   const { data: user, isLoading } = useQuery({
     queryKey: ['me'],
@@ -26,12 +32,19 @@ export default function MyPageEditPage() {
     },
   });
 
+  const { data: images = [] } = useQuery({
+    queryKey: ['me', 'images'],
+    queryFn: async () => {
+      const { data } = await api.get('/api/users/me/images');
+      return data.data as UserImgResponse[];
+    },
+  });
+
   const [name, setName] = useState('');
   const [tel, setTel] = useState('');
 
   const initialized = useRef(false);
   if (user && !initialized.current) {
-    setName(user.userName ?? '');
     setTel(user.userTel ?? '');
     initialized.current = true;
   }
@@ -45,12 +58,29 @@ export default function MyPageEditPage() {
     },
   });
 
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setPreview(URL.createObjectURL(file));
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const { data: uploadRes } = await api.post('/api/files/upload', formData);
+      const imgFileKey = uploadRes.data as string;
+      await api.post('/api/users/me/images', { imgFileKey });
+      setPreview(imgFileKey);
+      queryClient.invalidateQueries({ queryKey: ['me', 'images'] });
+    } catch {
+      alert('이미지 업로드에 실패했습니다.');
+    } finally {
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = '';
+    }
   };
 
+  const realImages = images.filter((img) => img.imgFileKey !== 'default');
+  const currentProfileUrl = realImages[realImages.length - 1]?.imgFileKey ?? null;
+  const displayImg = preview ?? currentProfileUrl;
   const initial = user?.userName?.[0] ?? '?';
 
   return (
@@ -70,26 +100,30 @@ export default function MyPageEditPage() {
         <div className="flex flex-col flex-1 overflow-y-auto">
           {/* 프로필 이미지 */}
           <div className="flex flex-col items-center py-8 border-b border-zinc-100">
-            <button onClick={() => fileRef.current?.click()} className="relative group">
+            <button onClick={() => !uploading && fileRef.current?.click()} className="relative group">
               <div className="w-20 h-20 rounded-full bg-[#C4B5FD] flex items-center justify-center overflow-hidden">
-                {preview ? (
-                  <img src={preview} alt="profile" className="w-full h-full object-cover" />
+                {displayImg ? (
+                  <img src={displayImg} alt="profile" className="w-full h-full object-cover" />
                 ) : (
                   <span className="text-[32px] font-bold text-white">{initial}</span>
                 )}
               </div>
               <div className="absolute inset-0 rounded-full bg-black/20 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="white" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
+                {uploading ? (
+                  <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                ) : (
+                  <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="white" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                )}
               </div>
             </button>
             <button
-              onClick={() => fileRef.current?.click()}
-              className="mt-2 text-[12px] text-zinc-500"
+              onClick={() => !uploading && fileRef.current?.click()}
+              className="mt-2 text-[12px] text-zinc-500 disabled:opacity-50"
             >
-              이미지 업로드
+              {uploading ? '업로드 중...' : '이미지 변경'}
             </button>
             <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImageChange} />
           </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -77,6 +77,13 @@ export default function MyPage() {
     router.push('/auth/login');
   };
 
+  const formatTel = (v: string) => {
+    const d = v.replace(/\D/g, '');
+    if (d.length < 4) return d;
+    if (d.length < 8) return `${d.slice(0, 3)}-${d.slice(3)}`;
+    return `${d.slice(0, 3)}-${d.slice(3, 7)}-${d.slice(7)}`;
+  };
+
   const realImages = images.filter((img) => img.imgFileKey !== 'default');
   const profileImgUrl = realImages[realImages.length - 1]?.imgFileKey ?? null;
   const initial = user?.userName?.[0] ?? '?';
@@ -85,7 +92,7 @@ export default function MyPage() {
     <div className="w-full h-screen bg-white flex flex-col max-w-[390px] mx-auto shadow-sm overflow-hidden">
       {/* 헤더 */}
       <header className="flex items-center px-4 h-[52px] shrink-0 border-b border-zinc-100">
-        <button onClick={() => router.back()} className="p-1 text-zinc-500 mr-2">
+        <button onClick={() => router.push('/main')} className="p-1 text-zinc-500 mr-2">
           <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
           </svg>
@@ -125,7 +132,7 @@ export default function MyPage() {
             </div>
             {[
               { label: '이름', value: user?.userName },
-              { label: '전화번호', value: user?.userTel },
+              { label: '전화번호', value: user?.userTel ? formatTel(user.userTel) : undefined },
               { label: '이메일', value: user?.userEmail },
             ].map(({ label, value }) => (
               <div key={label} className="flex items-center py-2.5">

--- a/src/app/mypage/profiles/page.tsx
+++ b/src/app/mypage/profiles/page.tsx
@@ -1,8 +1,8 @@
-'use client';
+﻿'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { useQuery, useQueries } from '@tanstack/react-query';
+import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
 
 const GROUP_COLORS = ['#fde68a', '#bfdbfe', '#bbf7d0', '#fecaca', '#ddd6fe', '#fed7aa'];
@@ -19,12 +19,15 @@ interface MemberResponse {
   memRole: string;
   memState: string;
   teamId: string;
+  memBio?: string;
+  userImg?: string;
 }
 
 interface Profile {
   memId: string;
   memNic: string;
   bio: string;
+  userImg: string | null;
   teamId: string;
   teamName: string;
   currentMember: number;
@@ -44,9 +47,34 @@ function XButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-function EditModal({ profile, onClose }: { profile: Profile; onClose: () => void }) {
+function EditModal({ profile, onClose, onSaved }: { profile: Profile; onClose: () => void; onSaved: (memNic: string, memBio: string) => void }) {
   const [nick, setNick] = useState(profile.memNic);
-  const [bio, setBio] = useState('');
+  const [bio, setBio] = useState(profile.bio);
+  const [preview, setPreview] = useState<string | null>(profile.userImg ?? null);
+  const [pendingImgKey, setPendingImgKey] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const { data: uploadRes } = await api.post('/api/files/upload', formData);
+      const imgFileKey = uploadRes.data as string;
+      setPreview(imgFileKey);
+      setPendingImgKey(imgFileKey);
+    } catch {
+      alert('이미지 업로드에 실패했습니다.');
+    } finally {
+      setUploading(false);
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
@@ -56,14 +84,23 @@ function EditModal({ profile, onClose }: { profile: Profile; onClose: () => void
 
         <div className="flex items-center gap-4 mb-5">
           <div
-            className="w-16 h-16 rounded-full flex items-center justify-center text-[22px] font-bold text-zinc-700 shrink-0"
+            className="w-16 h-16 rounded-full flex items-center justify-center text-[22px] font-bold text-zinc-700 shrink-0 overflow-hidden"
             style={{ backgroundColor: GROUP_COLORS[profile.colorIdx] }}
           >
-            {nick[0] || '?'}
+            {preview ? (
+              <img src={preview} alt="preview" className="w-full h-full object-cover" />
+            ) : (
+              nick[0] || '?'
+            )}
           </div>
-          <button className="flex-1 h-10 border border-zinc-300 rounded-xl text-[13px] font-medium text-zinc-700">
-            이미지 업로드
+          <button
+            onClick={() => !uploading && fileRef.current?.click()}
+            disabled={uploading}
+            className="flex-1 h-10 border border-zinc-300 rounded-xl text-[13px] font-medium text-zinc-700 disabled:opacity-50"
+          >
+            {uploading ? '업로드 중...' : '이미지 업로드'}
           </button>
+          <input ref={fileRef} type="file" accept="image/*" className="hidden" onChange={handleImageUpload} />
         </div>
 
         <div className="flex items-center gap-3 mb-3">
@@ -88,10 +125,23 @@ function EditModal({ profile, onClose }: { profile: Profile; onClose: () => void
         </div>
 
         <button
-          onClick={onClose}
-          className="w-full bg-[#3B3EFF] text-white text-[14px] font-semibold rounded-xl py-2.5"
+          disabled={saving || uploading}
+          onClick={async () => {
+            setSaving(true);
+            try {
+              await api.patch(`/api/members/${profile.memId}`, { memNic: nick, memBio: bio, ...(pendingImgKey && { memImgKey: pendingImgKey }) });
+              queryClient.invalidateQueries({ queryKey: ['memberMe', profile.teamId] });
+              onSaved(nick, bio);
+              onClose();
+            } catch {
+              alert('저장에 실패했습니다.');
+            } finally {
+              setSaving(false);
+            }
+          }}
+          className="w-full bg-[#3B3EFF] text-white text-[14px] font-semibold rounded-xl py-2.5 disabled:opacity-60"
         >
-          완료
+          {saving ? '저장 중...' : '완료'}
         </button>
       </div>
     </div>
@@ -154,7 +204,8 @@ export default function ProfilesPage() {
       return {
         memId: mem.memId,
         memNic: mem.memNic,
-        bio: '',
+        bio: mem.memBio ?? '',
+        userImg: mem.userImg ?? null,
         teamId: team.teamId,
         teamName: team.teamName,
         currentMember: team.currentMember,
@@ -165,7 +216,7 @@ export default function ProfilesPage() {
 
   return (
     <div className="w-full h-screen bg-white flex flex-col max-w-[390px] mx-auto shadow-sm overflow-hidden">
-      {editTarget && <EditModal profile={editTarget} onClose={() => setEditTarget(null)} />}
+      {editTarget && <EditModal profile={editTarget} onClose={() => setEditTarget(null)} onSaved={(memNic, memBio) => setEditTarget((prev) => prev ? { ...prev, memNic, bio: memBio } : null)} />}
       {teamsTarget && <UsedTeamsModal profile={teamsTarget} onClose={() => setTeamsTarget(null)} />}
 
       <header className="flex items-center px-4 h-[52px] shrink-0 border-b border-zinc-100">
@@ -184,10 +235,14 @@ export default function ProfilesPage() {
           profiles.map((profile) => (
             <div key={profile.memId} className="flex items-center gap-3 px-4 py-3 border-b border-zinc-100">
               <div
-                className="w-12 h-12 rounded-full shrink-0 flex items-center justify-center text-[18px] font-bold text-zinc-700"
+                className="w-12 h-12 rounded-full shrink-0 flex items-center justify-center text-[18px] font-bold text-zinc-700 overflow-hidden"
                 style={{ backgroundColor: GROUP_COLORS[profile.colorIdx] }}
               >
-                {profile.memNic[0]}
+                {profile.userImg ? (
+                  <img src={profile.userImg} alt="profile" className="w-full h-full object-cover" />
+                ) : (
+                  profile.memNic[0]
+                )}
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-[14px] font-semibold text-zinc-900 truncate">{profile.memNic}</p>


### PR DESCRIPTION
## Summary

- 마이페이지 편집 페이지: 이름 기본값 현재 이름으로 표시, placeholder 공백, 전화번호 자동 하이픈 포맷(`010-1234-5678`), 완료 시 `/api/users/me`로 저장 (기존 `/api/auth/me` 403 오류 수정)
- 마이페이지 목록: 전화번호 하이픈 형식 표시, `<` 버튼 항상 `/main`으로 이동
- 메인 우상단 프로필 버튼: 글로벌 프로필 사진(`USER_IMG`) 실제 표시
- 프로필 관리(`/mypage/profiles`): 이미지 업로드·닉네임·한줄소개 수정 저장 — 모임별 독립 프로필(`MEMBER.MEM_IMG_KEY`)로 메인 프사와 완전 분리

## Backend changes (same branch context)

- `PATCH /api/users/me` 추가 (UserInfoController)
- `MEMBER` 테이블에 `MEM_BIO`, `MEM_IMG_KEY` 컬럼 추가
- `PATCH /api/members/{memId}` 추가 (닉네임·한줄소개·이미지 저장)
- `MemberResponse`에 `userImg`, `memBio` 필드 추가

## Test plan

- [ ] 마이페이지 수정 → 이름/전화번호 저장 후 목록 반영 확인
- [ ] 전화번호 숫자 입력 시 자동 하이픈 포맷 확인
- [ ] 메인 우상단 프사 = 마이페이지 프사와 동일한지 확인
- [ ] 프로필 관리에서 이미지 변경 후 메인 프사는 그대로인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)