### PR TITLE
fix: 이미지 업로드 실패 시 1MB 제한 안내 문구 추가

### DIFF
--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -184,7 +184,7 @@ function JoinByCodeModal({ onClose, onSuccess }: { onClose: () => void, onSucces
       setSelectedImgId(newImg.imgId);
       refetchImages();
     } catch {
-      alert('이미지 업로드에 실패했습니다.');
+      alert('이미지 업로드에 실패했습니다. 1MB 이하 이미지만 업로드 가능합니다.');
     } finally {
       setUploading(false);
       e.target.value = '';

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -83,7 +83,7 @@ export default function MyPageEditPage() {
       setPreview(imgFileKey);
       queryClient.invalidateQueries({ queryKey: ['me', 'images'] });
     } catch {
-      alert('이미지 업로드에 실패했습니다.');
+      alert('이미지 업로드에 실패했습니다. 1MB 이하 이미지만 업로드 가능합니다.');
     } finally {
       setUploading(false);
       if (fileRef.current) fileRef.current.value = '';

--- a/src/app/mypage/profiles/page.tsx
+++ b/src/app/mypage/profiles/page.tsx
@@ -69,7 +69,7 @@ function EditModal({ profile, onClose, onSaved }: { profile: Profile; onClose: (
       setPreview(imgFileKey);
       setPendingImgKey(imgFileKey);
     } catch {
-      alert('이미지 업로드에 실패했습니다.');
+      alert('이미지 업로드에 실패했습니다. 1MB 이하 이미지만 업로드 가능합니다.');
     } finally {
       setUploading(false);
       if (fileRef.current) fileRef.current.value = '';


### PR DESCRIPTION
## Summary
- 마이페이지 편집, 모임별 프로필 수정 팝업, 모임 가입 팝업에서 이미지 업로드 실패 시 1MB 제한 안내 메시지 표시
- 미션 인증 이미지는 백엔드에서 10MB로 제한 증가 (Back-end PR #57 참고)

## 변경 파일
- `src/app/mypage/edit/page.tsx` — 마이페이지 프로필 이미지 업로드 실패 안내
- `src/app/mypage/profiles/page.tsx` — 모임별 프로필 수정 팝업 이미지 업로드 실패 안내
- `src/app/main/page.tsx` — 모임 가입 팝업 이미지 업로드 실패 안내

🤖 Generated with [Claude Code](https://claude.com/claude-code)