### PR TITLE
feat: 모임장 위임 기능 추가

### DIFF
--- a/src/app/[id]/members/[memberId]/page.tsx
+++ b/src/app/[id]/members/[memberId]/page.tsx
@@ -14,7 +14,6 @@ interface MemberResponse {
   procDtm: string | null;
   userId: string;
   teamId: string;
-  userImgId: number | null;
   imgFileKey: string | null;
 }
 
@@ -173,6 +172,7 @@ export default function MemberDetailPage() {
   const queryClient = useQueryClient();
   const [showEditModal, setShowEditModal] = useState(false);
   const [showKickConfirm, setShowKickConfirm] = useState(false);
+  const [showDelegateConfirm, setShowDelegateConfirm] = useState(false);
 
   const { data: myMembership } = useQuery({
     queryKey: ['memberMe', id],
@@ -227,6 +227,12 @@ export default function MemberDetailPage() {
     onSuccess: () => { invalidate(); router.back(); },
   });
 
+  const delegateMutation = useMutation({
+    mutationFn: () => api.patch(`/api/members/${memberId}/delegate`),
+    onSuccess: () => { invalidate(); setShowDelegateConfirm(false); router.back(); },
+    onError: () => { alert('위임에 실패했습니다. 다시 시도해주세요.'); },
+  });
+
   if (isLoading) {
     return <div className="text-center py-20 text-zinc-500 text-sm">불러오는 중...</div>;
   }
@@ -244,6 +250,32 @@ export default function MemberDetailPage() {
 
   return (
     <div className="pt-6 px-1">
+      {showDelegateConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
+          <div className="bg-white rounded-2xl w-full max-w-[300px] p-6 shadow-xl">
+            <h3 className="text-[16px] font-bold text-zinc-900 text-center mb-2">모임장 위임</h3>
+            <p className="text-[13px] text-zinc-500 text-center mb-6">
+              <span className="font-semibold text-zinc-800">{member?.memNic}</span> 님에게 모임장을 위임할까요?{'\n'}위임 후 되돌릴 수 없습니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDelegateConfirm(false)}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-medium text-zinc-600 border border-zinc-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => delegateMutation.mutate()}
+                disabled={delegateMutation.isPending}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-semibold text-white bg-[#3B3EFF] disabled:opacity-60"
+              >
+                {delegateMutation.isPending ? '처리 중...' : '위임하기'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {showKickConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
           <div className="bg-white rounded-2xl w-full max-w-[300px] p-6 shadow-xl">
@@ -356,10 +388,18 @@ export default function MemberDetailPage() {
       )}
 
       {isLeader && !isOwnProfile && member.memState === 'A' && (
-        <div className="pt-2">
+        <div className="flex gap-3 pt-2">
+          {member.memRole === 'M' && (
+            <button
+              onClick={() => setShowDelegateConfirm(true)}
+              className="flex-1 py-3 rounded-xl text-[14px] font-semibold text-[#3B3EFF] border border-[#3B3EFF]"
+            >
+              모임장 위임
+            </button>
+          )}
           <button
             onClick={() => setShowKickConfirm(true)}
-            className="w-full py-3 rounded-xl text-[14px] font-semibold text-red-500 border border-red-200"
+            className="flex-1 py-3 rounded-xl text-[14px] font-semibold text-red-500 border border-red-200"
           >
             강퇴
           </button>

--- a/src/app/[id]/members/page.tsx
+++ b/src/app/[id]/members/page.tsx
@@ -15,7 +15,6 @@ interface MemberResponse {
   procDtm: string | null;
   userId: string;
   teamId: string;
-  userImgId: number | null;
   imgFileKey: string | null;
 }
 

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -1,7 +1,7 @@
-﻿'use client';
+'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import api from '@/lib/api';
@@ -58,7 +58,6 @@ interface TeamResponse {
 
 
 
-const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
 const AUTH_COLOR: Record<string, string> = { 'AI인증': '#3B3EFF', '수동인증': '#31DBD5' };
 
 function deadlineColor(d: string | null) {
@@ -539,6 +538,25 @@ export default function MainPage() {
   const [newsLimit, setNewsLimit] = useState(5);
   const queryClient = useQueryClient();
 
+  useEffect(() => {
+    const raw = localStorage.getItem('token');
+    if (!raw || raw === 'null') {
+      localStorage.removeItem('token');
+      router.replace('/auth/login');
+      return;
+    }
+    try {
+      const payload = JSON.parse(atob(raw.split('.')[1]));
+      if (payload.exp * 1000 <= Date.now()) {
+        localStorage.removeItem('token');
+        router.replace('/auth/login');
+      }
+    } catch {
+      localStorage.removeItem('token');
+      router.replace('/auth/login');
+    }
+  }, [router]);
+
   const { data: user } = useQuery({
     queryKey: ['me'],
     queryFn: async () => {
@@ -563,7 +581,7 @@ export default function MainPage() {
   const realProfileImages = profileImages.filter((img) => img.imgFileKey !== 'default');
   const profileImg = realProfileImages[realProfileImages.length - 1]?.imgFileKey ?? null;
 
-  const { data: myTeams} = useQuery({
+  const { data: myTeams } = useQuery({
     queryKey: ['myTeams'],
     queryFn: async () => {
       const { data } = await api.get('/api/teams/my');


### PR DESCRIPTION
## Summary

- 모임장이 일반 멤버에게 모임장 권한을 위임할 수 있는 기능 추가
- 멤버 상세 페이지에서 위임 버튼 노출 (모임장 본인에게만)
- 위임 확인 팝업으로 실수 방지
- 만료된 JWT 토큰 자동 감지 후 로그인 페이지로 리디렉션

## Test plan

- [ ] 모임장으로 로그인 후 멤버 상세 페이지 진입
- [ ] 모임장 위임 버튼 클릭 → 확인 팝업 노출 확인
- [ ] 위임 완료 후 해당 멤버가 모임장으로 변경되는지 확인
- [ ] 위임 후 기존 모임장이 일반 멤버로 변경되는지 확인
- [ ] 토큰 만료 시 로그인 페이지로 자동 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)