### PR TITLE
feat: 회의록 UI 개선 및 녹음 페이지 리디자인

### DIFF
--- a/src/app/[id]/_components/GroupHeader.tsx
+++ b/src/app/[id]/_components/GroupHeader.tsx
@@ -12,6 +12,7 @@ interface MemberMe {
   memNic: string;
   memRole: string;
   memState: string;
+  imgFileKey: string | null;
 }
 
 export default function GroupHeader() {
@@ -59,10 +60,17 @@ export default function GroupHeader() {
   };
 
   const handleBack = () => {
+    if (pageHeader?.onBack) {
+      pageHeader.onBack();
+      return;
+    }
     const parts = pathname.split('/').filter(Boolean);
-    const isDetailPage = parts.length >= 3; // e.g., /[id]/events/123
+    const isSubPage = pathname.includes('/new') || pathname.includes('/create') || pathname.includes('/info');
+    const isDetailPage = parts.length >= 3 && !isSubPage;
 
-    if (pathname.includes('/new') || pathname.includes('/create') || pathname.includes('/info') || isDetailPage) {
+    if (isDetailPage) {
+      router.push(`/${parts[0]}/${parts[1]}`);
+    } else if (isSubPage) {
       router.back();
     } else {
       router.push('/main');
@@ -126,8 +134,11 @@ export default function GroupHeader() {
 
             {/* 모임 내 프로필 */}
             <div className="flex items-center gap-2.5 px-3.5 py-3 border-b border-zinc-100">
-              <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
-                <span className="text-[13px] font-bold text-white">{initial}</span>
+              <div className="w-8 h-8 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0 overflow-hidden">
+                {myMember?.imgFileKey
+                  ? <img src={myMember.imgFileKey} alt="프로필" className="w-full h-full object-cover" />
+                  : <span className="text-[13px] font-bold text-white">{initial}</span>
+                }
               </div>
               <p className="text-[13px] font-bold text-zinc-900 truncate">{myMember?.memNic ?? '...'}</p>
             </div>

--- a/src/app/[id]/minutes/new/page.tsx
+++ b/src/app/[id]/minutes/new/page.tsx
@@ -1,117 +1,89 @@
 'use client';
 
 import { useRouter, useParams } from 'next/navigation';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
+import { useHeaderSlotStore } from '@/store/headerSlot';
 
 export default function MinutesNewPage() {
   const router = useRouter();
   const { id } = useParams<{ id: string }>();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { setPageHeader } = useHeaderSlotStore();
 
-  // 파일 업로드 선택 시 → record 페이지로 파일 전달
-  // sessionStorage를 활용해 파일 객체를 임시 보관
+  useEffect(() => {
+    setPageHeader({ title: '회의록 생성하기', hideHamburger: true });
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    // 지원 형식 검증
     const allowed = ['audio/mpeg', 'audio/mp3', 'audio/wav', 'audio/x-m4a', 'audio/mp4'];
     if (!allowed.includes(file.type)) {
       alert('지원하지 않는 형식입니다.\nmp3, wav, m4a 파일만 업로드 가능합니다.');
       return;
     }
 
-    // 파일을 sessionStorage에 임시 저장 후 record 페이지로 이동
-    // (실제로는 File 객체를 직접 전달할 수 없으므로 전역 상태 또는 URL params 활용)
-    // 여기서는 record 페이지에서 처리하도록 query string으로 mode만 전달
-    const dataTransfer = new DataTransfer();
-    dataTransfer.items.add(file);
-
-    // window.__uploadedAudio 에 임시 보관 (가장 심플한 방법)
     (window as any).__uploadedAudio = file;
     router.push(`/${id}/minutes/recode?mode=upload`);
   };
 
   return (
-    <div className="flex flex-col min-h-full bg-zinc-100">
-      {/* 헤더 */}
-      <div className="flex items-center px-4 py-5 gap-3">
-        <button
-          onClick={() => router.back()}
-          className="text-zinc-500 text-[14px]"
-        >
-          ← 돌아가기
-        </button>
-        <span className="flex-1 text-center text-[16px] font-semibold text-zinc-800 pr-14">
-          새 회의록
-        </span>
-      </div>
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-6 pb-10 flex flex-col gap-4">
 
-      {/* 선택 카드 영역 */}
-      <div className="flex flex-col gap-4 px-4 pt-4">
+      <p className="text-[13px] text-zinc-400 px-1">회의록을 만들 방법을 선택해주세요.</p>
 
-        {/* 녹음 시작 카드 */}
-        <button
-          onClick={() => router.push(`/${id}/minutes/recode?mode=record`)}
-          className="bg-white rounded-2xl px-5 py-6 flex items-center gap-4 active:bg-zinc-50 transition-colors text-left w-full"
-        >
-          <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center shrink-0">
-            <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#E24B4A" strokeWidth={1.8}>
-              <path strokeLinecap="round" strokeLinejoin="round"
-                d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
-              <path strokeLinecap="round" strokeLinejoin="round"
-                d="M19 10v2a7 7 0 0 1-14 0v-2" />
-              <line x1="12" y1="19" x2="12" y2="23" strokeLinecap="round" />
-              <line x1="8" y1="23" x2="16" y2="23" strokeLinecap="round" />
-            </svg>
-          </div>
-          <div>
-            <p className="text-[15px] font-semibold text-zinc-800">녹음 시작</p>
-            <p className="text-[13px] text-zinc-400 mt-0.5">
-              지금 바로 회의를 녹음합니다
-            </p>
-          </div>
-          <svg className="ml-auto text-zinc-300" width="18" height="18" fill="none"
-            viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+      {/* 녹음 시작 */}
+      <button
+        onClick={() => router.push(`/${id}/minutes/recode?mode=record`)}
+        className="bg-white rounded-2xl p-5 flex items-center gap-4 active:bg-zinc-50 transition-colors text-left w-full shadow-sm"
+      >
+        <div className="w-12 h-12 rounded-2xl bg-red-50 flex items-center justify-center shrink-0">
+          <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#E24B4A" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 10v2a7 7 0 0 1-14 0v-2" />
+            <line x1="12" y1="19" x2="12" y2="23" strokeLinecap="round" />
+            <line x1="8" y1="23" x2="16" y2="23" strokeLinecap="round" />
           </svg>
-        </button>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[15px] font-semibold text-zinc-900">녹음 시작</p>
+          <p className="text-[13px] text-zinc-400 mt-0.5">지금 바로 회의를 녹음합니다</p>
+        </div>
+        <svg className="text-zinc-300 shrink-0" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+        </svg>
+      </button>
 
-        {/* 파일 업로드 카드 */}
-        <button
-          onClick={() => fileInputRef.current?.click()}
-          className="bg-white rounded-2xl px-5 py-6 flex items-center gap-4 active:bg-zinc-50 transition-colors text-left w-full"
-        >
-          <div className="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center shrink-0">
-            <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#378ADD" strokeWidth={1.8}>
-              <path strokeLinecap="round" strokeLinejoin="round"
-                d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
-              <polyline strokeLinecap="round" strokeLinejoin="round"
-                points="16 8 12 4 8 8" />
-              <line x1="12" y1="4" x2="12" y2="16" strokeLinecap="round" />
-            </svg>
-          </div>
-          <div>
-            <p className="text-[15px] font-semibold text-zinc-800">파일 업로드</p>
-            <p className="text-[13px] text-zinc-400 mt-0.5">
-              mp3, wav, m4a 파일 지원
-            </p>
-          </div>
-          <svg className="ml-auto text-zinc-300" width="18" height="18" fill="none"
-            viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+      {/* 파일 업로드 */}
+      <button
+        onClick={() => fileInputRef.current?.click()}
+        className="bg-white rounded-2xl p-5 flex items-center gap-4 active:bg-zinc-50 transition-colors text-left w-full shadow-sm"
+      >
+        <div className="w-12 h-12 rounded-2xl bg-[#EBEBFF] flex items-center justify-center shrink-0">
+          <svg width="22" height="22" fill="none" viewBox="0 0 24 24" stroke="#3B3EFF" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
+            <polyline strokeLinecap="round" strokeLinejoin="round" points="16 8 12 4 8 8" />
+            <line x1="12" y1="4" x2="12" y2="16" strokeLinecap="round" />
           </svg>
-        </button>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[15px] font-semibold text-zinc-900">파일 업로드</p>
+          <p className="text-[13px] text-zinc-400 mt-0.5">mp3, wav, m4a 파일 지원</p>
+        </div>
+        <svg className="text-zinc-300 shrink-0" width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+        </svg>
+      </button>
 
-        {/* 숨겨진 파일 input */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="audio/mpeg,audio/mp3,audio/wav,audio/x-m4a,audio/mp4,.mp3,.wav,.m4a"
-          className="hidden"
-          onChange={handleFileChange}
-        />
-      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/mpeg,audio/mp3,audio/wav,audio/x-m4a,audio/mp4,.mp3,.wav,.m4a"
+        className="hidden"
+        onChange={handleFileChange}
+      />
     </div>
   );
 }

--- a/src/app/[id]/minutes/recode/page.tsx
+++ b/src/app/[id]/minutes/recode/page.tsx
@@ -2,16 +2,13 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter, useParams, useSearchParams } from 'next/navigation';
+import { useHeaderSlotStore } from '@/store/headerSlot';
 import api from '@/lib/api';
 
-// ─── 타입 정의 ───────────────────────────────────────────────
 type RecordingState = 'idle' | 'recording' | 'paused' | 'uploading' | 'done' | 'error';
-type UploadStep = 0 | 1 | 2; // 0=대기, 1=업로드 중, 2=완료
 
-// ─── 상수 ────────────────────────────────────────────────────
 const NUM_BARS = 40;
 
-// ─── 유틸 ────────────────────────────────────────────────────
 function formatTime(totalSeconds: number): string {
   const h = Math.floor(totalSeconds / 3600);
   const m = Math.floor((totalSeconds % 3600) / 60);
@@ -20,19 +17,20 @@ function formatTime(totalSeconds: number): string {
   return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
 }
 
-// ─── 메인 컴포넌트 ────────────────────────────────────────────
 export default function RecordPage() {
   const router = useRouter();
   const params = useParams<{ id: string }>();
   const searchParams = useSearchParams();
   const teamId = params?.id ?? '';
-  const mode = searchParams.get('mode'); // 'record' | 'upload'
+  const mode = searchParams.get('mode');
+
+  const { setPageHeader } = useHeaderSlotStore();
 
   const [recordingState, setRecordingState] = useState<RecordingState>('idle');
   const [seconds, setSeconds] = useState(0);
   const [barHeights, setBarHeights] = useState<number[]>(Array(NUM_BARS).fill(6));
-  const [showStopPopup, setShowStopPopup] = useState(false);
-  const [uploadStep, setUploadStep] = useState<UploadStep>(0);
+  const [showStopModal, setShowStopModal] = useState(false);
+  const [showLeaveModal, setShowLeaveModal] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
 
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -41,56 +39,61 @@ export default function RecordPage() {
   const waveRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
 
-  // ── 공통 업로드 함수 ──────────────────────────────────────
-  // API가 즉시 status='P' 로 응답하므로 단계가 2개로 단순화됨
-  const uploadAudio = useCallback(
-    async (blob: Blob, filename: string) => {
-      setRecordingState('uploading');
-      setUploadStep(0);
+  useEffect(() => {
+    const isActive = recordingState === 'recording' || recordingState === 'paused';
+    setPageHeader({
+      title: mode === 'upload' ? '파일 업로드' : '녹음 중',
+      hideHamburger: true,
+      onBack: isActive
+        ? () => setShowLeaveModal(true)
+        : undefined,
+    });
+  }, [setPageHeader, mode, recordingState]);
 
-      try {
-        setUploadStep(1); // 서버에 업로드 중
+  useEffect(() => {
+    return () => setPageHeader(null);
+  }, [setPageHeader]);
 
-        const formData = new FormData();
-        formData.append('audio', blob, filename);
-        formData.append('teamId', teamId);
-
-        // api 인스턴스 사용 → Authorization 헤더 자동 첨부 (lib/api.ts 인터셉터)
-        const { data: result } = await api.post('/api/meeting-records', formData);
-
-        // 업로드 완료 — AI 처리는 백그라운드에서 진행
-        setUploadStep(2);
-        setRecordingState('done');
-
-        setTimeout(() => {
-          router.push(`/${teamId}/minutes/${result.data?.meetingId}`);
-        }, 1500);
-      } catch (err: unknown) {
-        const msg =
-          (err as { response?: { data?: { message?: string } } })?.response?.data?.message
-          ?? (err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.');
-        setErrorMsg(msg);
+  const uploadAudio = useCallback(async (blob: Blob, filename: string) => {
+    setRecordingState('uploading');
+    try {
+      const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+      if (!token) {
+        setErrorMsg('로그인이 필요합니다. 다시 로그인해 주세요.');
         setRecordingState('error');
+        return;
       }
-    },
-    [teamId, router],
-  );
+      const formData = new FormData();
+      formData.append('audio', blob, filename);
+      formData.append('teamId', teamId);
+      const { data: result } = await api.post('/api/meeting-records', formData, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setRecordingState('done');
+      setTimeout(() => {
+        router.push(`/${teamId}/minutes/${result.data?.meetingId}`);
+      }, 1500);
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      const msg =
+        status === 403
+          ? '인증이 만료되었습니다. 다시 로그인해 주세요.'
+          : ((err as { response?: { data?: { message?: string } } })?.response?.data?.message
+            ?? (err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.'));
+      setErrorMsg(msg);
+      setRecordingState('error');
+    }
+  }, [teamId, router]);
 
-  // ── 녹음 시작 ─────────────────────────────────────────────
   const startRecording = useCallback(async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
       chunksRef.current = [];
-
       const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-        ? 'audio/webm;codecs=opus'
-        : 'audio/webm';
-
+        ? 'audio/webm;codecs=opus' : 'audio/webm';
       const recorder = new MediaRecorder(stream, { mimeType });
-      recorder.ondataavailable = (e) => {
-        if (e.data.size > 0) chunksRef.current.push(e.data);
-      };
+      recorder.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
       recorder.start(100);
       mediaRecorderRef.current = recorder;
       setRecordingState('recording');
@@ -100,19 +103,12 @@ export default function RecordPage() {
     }
   }, []);
 
-  // ── 페이지 진입 시 mode에 따라 분기 ─────────────────────────
   useEffect(() => {
     if (mode === 'upload') {
       const file = (window as Window & { __uploadedAudio?: File }).__uploadedAudio;
-      if (!file) {
-        router.replace(`/${teamId}/minutes/new`);
-        return;
-      }
+      if (!file) { router.replace(`/${teamId}/minutes/new`); return; }
       uploadAudio(file, file.name);
-    } else {
-      startRecording();
     }
-
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
       if (waveRef.current) clearInterval(waveRef.current);
@@ -120,7 +116,6 @@ export default function RecordPage() {
     };
   }, [mode]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // ── 타이머 ────────────────────────────────────────────────
   useEffect(() => {
     if (recordingState === 'recording') {
       timerRef.current = setInterval(() => setSeconds((s) => s + 1), 1000);
@@ -130,18 +125,15 @@ export default function RecordPage() {
     return () => { if (timerRef.current) clearInterval(timerRef.current); };
   }, [recordingState]);
 
-  // ── 파형 애니메이션 ────────────────────────────────────────
   useEffect(() => {
     if (recordingState === 'recording') {
       waveRef.current = setInterval(() => {
-        setBarHeights(
-          Array.from({ length: NUM_BARS }, (_, i) => {
-            const center = NUM_BARS / 2;
-            const dist = Math.abs(i - center) / center;
-            const max = 52 * (1 - dist * 0.4);
-            return Math.max(4, Math.random() * max + 4);
-          }),
-        );
+        setBarHeights(Array.from({ length: NUM_BARS }, (_, i) => {
+          const center = NUM_BARS / 2;
+          const dist = Math.abs(i - center) / center;
+          const max = 52 * (1 - dist * 0.4);
+          return Math.max(4, Math.random() * max + 4);
+        }));
       }, 90);
     } else {
       if (waveRef.current) clearInterval(waveRef.current);
@@ -161,287 +153,211 @@ export default function RecordPage() {
     }
   };
 
-  const handleStopClick = () => setShowStopPopup(true);
-  const handleCancelStop = () => setShowStopPopup(false);
-
   const handleConfirmStop = async () => {
-    setShowStopPopup(false);
+    setShowStopModal(false);
     const blob = await new Promise<Blob>((resolve) => {
       const recorder = mediaRecorderRef.current!;
-      recorder.onstop = () => {
-        resolve(new Blob(chunksRef.current, { type: recorder.mimeType }));
-      };
+      recorder.onstop = () => resolve(new Blob(chunksRef.current, { type: recorder.mimeType }));
       recorder.stop();
     });
     streamRef.current?.getTracks().forEach((t) => t.stop());
     await uploadAudio(blob, 'recording.webm');
   };
 
-  const handleBack = () => {
-    streamRef.current?.getTracks().forEach((t) => t.stop());
-    router.push(`/${teamId}/minutes`);
-  };
+  const statusColor =
+    recordingState === 'recording' ? 'bg-red-500' :
+    recordingState === 'done'      ? 'bg-emerald-500' :
+    recordingState === 'error'     ? 'bg-red-500' : 'bg-zinc-400';
+
+  const statusLabel =
+    recordingState === 'idle'      ? '준비 중' :
+    recordingState === 'recording' ? '녹음 중' :
+    recordingState === 'paused'    ? '일시정지' :
+    recordingState === 'uploading' ? '업로드 중' :
+    recordingState === 'done'      ? '업로드 완료' : '오류 발생';
+
+  const fileName = mode === 'upload'
+    ? ((window as Window & { __uploadedAudio?: File }).__uploadedAudio?.name ?? '')
+    : 'recording.webm';
 
   return (
-    <div style={styles.page}>
-      {/* 헤더 */}
-      <div style={styles.header}>
-        <button
-          style={styles.backBtn}
-          onClick={handleBack}
-          disabled={recordingState === 'uploading'}
-          aria-label="회의록 목록으로 돌아가기"
-        >
-          ← 돌아가기
-        </button>
-        <span style={styles.headerTitle}>새 회의록</span>
-        <span style={{ width: 80 }} />
-      </div>
+    <div className="-mx-4 -mb-5 min-h-full bg-zinc-100 px-4 pt-6 pb-10 flex flex-col gap-4">
 
       {/* 메인 카드 */}
-      <div style={styles.card}>
+      <div className="bg-white rounded-2xl p-6 flex flex-col gap-6 shadow-sm">
+
         {/* 상태 뱃지 */}
-        <div style={styles.statusRow}>
-          <span
-            style={{
-              ...styles.dot,
-              background:
-                recordingState === 'recording' ? '#E24B4A'
-                : recordingState === 'done'      ? '#1D9E75'
-                : recordingState === 'error'     ? '#E24B4A'
-                : '#888780',
-              animation:
-                recordingState === 'recording' ? 'pulseDot 1.2s ease-in-out infinite' : 'none',
-            }}
-          />
-          <span style={styles.statusLabel}>
-            {recordingState === 'idle'      && '준비 중'}
-            {recordingState === 'recording' && '녹음 중'}
-            {recordingState === 'paused'    && '일시정지'}
-            {recordingState === 'uploading' && '업로드 중'}
-            {recordingState === 'done'      && '업로드 완료'}
-            {recordingState === 'error'     && '오류 발생'}
-          </span>
-          <span style={styles.fileLabel}>
-            {mode === 'upload'
-              ? ((window as Window & { __uploadedAudio?: File }).__uploadedAudio?.name ?? '')
-              : 'recording.webm'}
-          </span>
+        <div className="flex items-center gap-2.5">
+          <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${statusColor} ${recordingState === 'recording' ? 'animate-pulse' : ''}`} />
+          <span className="text-[14px] font-semibold text-zinc-800 flex-1">{statusLabel}</span>
+          {fileName && (
+            <span className="text-[11px] text-zinc-400 font-mono truncate max-w-[140px]">{fileName}</span>
+          )}
         </div>
 
-        {/* 타이머 — 녹음 모드에서만 표시 */}
+        {/* 타이머 */}
         {mode !== 'upload' && (
-          <div style={styles.timer} aria-live="polite">
-            {formatTime(seconds)}
+          <div className="text-center">
+            <span className="text-[52px] font-medium tracking-widest text-zinc-900 font-mono tabular-nums">
+              {formatTime(seconds)}
+            </span>
           </div>
         )}
 
-        {/* 파형 — 녹음 중에만 표시 */}
+        {/* 파형 */}
         {mode !== 'upload' && (
-          <div style={styles.waveform} aria-hidden="true">
+          <div className="flex items-center justify-center gap-[3px] h-16" aria-hidden="true">
             {barHeights.map((h, i) => (
               <div
                 key={i}
+                className="w-1 rounded-full shrink-0 transition-all"
                 style={{
-                  ...styles.bar,
                   height: `${Math.round(h)}px`,
-                  background:
-                    recordingState === 'recording'
-                      ? `hsl(${1 + i * 3}, 72%, ${52 + (h / 60) * 12}%)`
-                      : '#D3D1C7',
-                  transition:
-                    recordingState === 'recording' ? 'height 0.09s ease' : 'height 0.3s ease',
+                  backgroundColor: recordingState === 'recording'
+                    ? `hsl(239, 90%, ${52 + (h / 60) * 15}%)`
+                    : '#d4d4d8',
+                  transitionDuration: recordingState === 'recording' ? '90ms' : '300ms',
                 }}
               />
             ))}
           </div>
         )}
 
+        {/* 녹음 시작 버튼 (idle) */}
+        {recordingState === 'idle' && mode !== 'upload' && (
+          <div className="flex flex-col items-center gap-4 py-2">
+            <button
+              onClick={startRecording}
+              className="w-14 h-14 rounded-full bg-[#3B3EFF] flex items-center justify-center shadow-lg active:scale-95 transition-transform"
+            >
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="white">
+                <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 10v2a7 7 0 0 1-14 0v-2" fill="none" stroke="white" strokeWidth={1.8} />
+              </svg>
+            </button>
+            <p className="text-[13px] text-zinc-400">버튼을 눌러 녹음을 시작하세요</p>
+          </div>
+        )}
+
         {/* 녹음 조작 버튼 */}
         {(recordingState === 'recording' || recordingState === 'paused') && (
-          <div style={styles.btnRow}>
-            <button style={styles.btnSecondary} onClick={handlePauseResume}>
-              {recordingState === 'paused' ? '▶ 재개' : '⏸ 일시정지'}
+          <div className="flex gap-3">
+            <button
+              onClick={handlePauseResume}
+              className="flex-1 py-3 rounded-xl text-[14px] font-semibold text-zinc-600 bg-zinc-100 flex items-center justify-center gap-1.5"
+            >
+              {recordingState === 'paused' ? (
+                <><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>재개</>
+              ) : (
+                <><svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>일시정지</>
+              )}
             </button>
-            <button style={styles.btnDanger} onClick={handleStopClick}>
-              ⏹ 중지
+            <button
+              onClick={() => setShowStopModal(true)}
+              className="flex-1 py-3 rounded-xl text-[14px] font-semibold text-red-500 border border-red-200 bg-white flex items-center justify-center gap-1.5"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h12v12H6z"/></svg>
+              중지
             </button>
           </div>
         )}
 
-        {/* 업로드 진행 상태 */}
-        {recordingState === 'uploading' && <UploadProgress step={uploadStep} />}
+        {/* 업로드 중 */}
+        {recordingState === 'uploading' && (
+          <div className="flex flex-col items-center gap-4 py-2">
+            <div className="w-9 h-9 border-[3px] border-zinc-200 border-t-[#3B3EFF] rounded-full animate-spin" />
+            <p className="text-[14px] text-zinc-500">서버에 파일 업로드 중...</p>
+          </div>
+        )}
 
         {/* 완료 */}
         {recordingState === 'done' && (
-          <div style={styles.doneMsg}>
-            <span style={{ fontSize: 28 }}>✅</span>
-            <p style={{ margin: '8px 0 4px', fontWeight: 500 }}>업로드 완료!</p>
-            <p style={{ fontSize: 13, color: '#888780' }}>
-              AI가 회의록을 분석하고 있어요.
-              <br />잠시 후 상세 페이지로 이동합니다...
+          <div className="flex flex-col items-center gap-2 py-2">
+            <div className="w-12 h-12 rounded-full bg-emerald-50 flex items-center justify-center">
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#10b981" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7"/>
+              </svg>
+            </div>
+            <p className="text-[15px] font-semibold text-zinc-900">업로드 완료!</p>
+            <p className="text-[13px] text-zinc-400 text-center leading-relaxed">
+              AI가 회의록을 분석하고 있어요.<br />잠시 후 상세 페이지로 이동합니다...
             </p>
           </div>
         )}
 
         {/* 에러 */}
         {recordingState === 'error' && (
-          <div style={styles.errorMsg}>
-            <p style={{ margin: '0 0 12px', fontWeight: 500, color: '#E24B4A' }}>{errorMsg}</p>
-            <button style={styles.btnSecondary} onClick={handleBack}>
+          <div className="flex flex-col items-center gap-4 py-2">
+            <div className="w-12 h-12 rounded-full bg-red-50 flex items-center justify-center">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#ef4444" strokeWidth={2.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+              </svg>
+            </div>
+            <p className="text-[14px] font-medium text-red-500 text-center">{errorMsg}</p>
+            <button
+              onClick={() => { streamRef.current?.getTracks().forEach((t) => t.stop()); router.push(`/${teamId}/minutes`); }}
+              className="w-full py-3 rounded-xl text-[14px] font-semibold bg-zinc-100 text-zinc-600"
+            >
               목록으로 돌아가기
             </button>
           </div>
         )}
       </div>
 
-      {showStopPopup && (
-        <StopConfirmPopup onCancel={handleCancelStop} onConfirm={handleConfirmStop} />
+      {/* 나가기 확인 모달 */}
+      {showLeaveModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
+          <div className="bg-white rounded-2xl w-full max-w-[300px] p-6 shadow-xl">
+            <h3 className="text-[16px] font-bold text-zinc-900 text-center mb-2">녹음을 중단할까요?</h3>
+            <p className="text-[13px] text-zinc-500 text-center mb-6 leading-relaxed">
+              지금 나가면 녹음 기록이 사라집니다.<br />정말 나가시겠습니까?
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowLeaveModal(false)}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-medium text-zinc-600 border border-zinc-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => {
+                  streamRef.current?.getTracks().forEach((t) => t.stop());
+                  router.push(`/${teamId}/minutes`);
+                }}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-semibold text-white bg-red-500"
+              >
+                나가기
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
-      <style>{`
-        @keyframes pulseDot {
-          0%, 100% { opacity: 1; transform: scale(1); }
-          50%       { opacity: 0.4; transform: scale(0.85); }
-        }
-        @keyframes spin {
-          to { transform: rotate(360deg); }
-        }
-      `}</style>
-    </div>
-  );
-}
-
-// ─── 업로드 진행 컴포넌트 (2단계로 단순화) ───────────────────
-function UploadProgress({ step }: { step: UploadStep }) {
-  const steps = [
-    { label: '서버에 파일 업로드 중...', icon: '☁️' },
-    { label: 'AI 분석 요청 완료 (백그라운드 처리 중)', icon: '🤖' },
-  ];
-
-  return (
-    <div style={{ textAlign: 'center', paddingTop: 8 }}>
-      <div
-        style={{
-          width: 36,
-          height: 36,
-          border: '3px solid #D3D1C7',
-          borderTopColor: '#378ADD',
-          borderRadius: '50%',
-          margin: '0 auto 20px',
-          animation: 'spin 0.8s linear infinite',
-        }}
-      />
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10, textAlign: 'left' }}>
-        {steps.map((s, i) => {
-          const isDone = step > i + 1;
-          const isActive = step === i + 1;
-          return (
-            <div
-              key={i}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 10,
-                fontSize: 14,
-                color: isDone ? '#1D9E75' : isActive ? '#378ADD' : '#B4B2A9',
-                fontWeight: isActive ? 500 : 400,
-                transition: 'color 0.3s',
-              }}
-            >
-              <span style={{ fontSize: 16 }}>{isDone ? '✅' : s.icon}</span>
-              {s.label}
+      {/* 중지 확인 모달 */}
+      {showStopModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/50">
+          <div className="bg-white rounded-2xl w-full max-w-[300px] p-6 shadow-xl">
+            <h3 className="text-[16px] font-bold text-zinc-900 text-center mb-2">녹음을 종료할까요?</h3>
+            <p className="text-[13px] text-zinc-500 text-center mb-6 leading-relaxed">
+              녹음을 중지하고 파일을 저장합니다.<br />이 작업은 취소할 수 없습니다.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowStopModal(false)}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-medium text-zinc-600 border border-zinc-200"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleConfirmStop}
+                className="flex-1 py-2.5 rounded-xl text-[14px] font-semibold text-white bg-[#3B3EFF]"
+              >
+                확인
+              </button>
             </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ─── 중지 확인 팝업 ───────────────────────────────────────────
-function StopConfirmPopup({ onCancel, onConfirm }: { onCancel: () => void; onConfirm: () => void }) {
-  return (
-    <div
-      style={{
-        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.45)',
-        display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 9999,
-      }}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="stop-popup-title"
-    >
-      <div style={styles.popup}>
-        <p id="stop-popup-title" style={styles.popupTitle}>녹음을 종료하시겠습니까?</p>
-        <p style={styles.popupDesc}>
-          녹음을 중지하고 파일을 저장합니다.<br />이 작업은 취소할 수 없습니다.
-        </p>
-        <div style={styles.popupBtns}>
-          <button style={styles.popupCancel} onClick={onCancel}>취소</button>
-          <button style={styles.popupConfirm} onClick={onConfirm}>확인</button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }
-
-// ─── 스타일 ───────────────────────────────────────────────────
-const styles: Record<string, React.CSSProperties> = {
-  page: {
-    minHeight: '100vh', background: '#F1EFE8', display: 'flex',
-    flexDirection: 'column', alignItems: 'center', padding: '0 16px 40px',
-    fontFamily: "'Pretendard', 'Apple SD Gothic Neo', sans-serif",
-  },
-  header: {
-    width: '100%', maxWidth: 520, display: 'flex', alignItems: 'center',
-    justifyContent: 'space-between', padding: '20px 0 16px',
-  },
-  headerTitle: { fontSize: 17, fontWeight: 500, color: '#2C2C2A' },
-  backBtn: {
-    background: 'none', border: 'none', fontSize: 14, color: '#5F5E5A',
-    cursor: 'pointer', padding: '4px 0', width: 80, textAlign: 'left',
-  },
-  card: {
-    width: '100%', maxWidth: 520, background: '#FFFFFF',
-    border: '0.5px solid rgba(0,0,0,0.1)', borderRadius: 16, padding: '28px 24px',
-  },
-  statusRow: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20 },
-  dot: { width: 10, height: 10, borderRadius: '50%', flexShrink: 0 },
-  statusLabel: { fontSize: 14, fontWeight: 500, color: '#444441', flex: 1 },
-  fileLabel: { fontSize: 12, color: '#888780', fontFamily: 'monospace' },
-  timer: {
-    fontSize: 48, fontWeight: 500, letterSpacing: 3, textAlign: 'center', color: '#2C2C2A',
-    fontFamily: "'SF Mono', 'Fira Code', 'Courier New', monospace", marginBottom: 24,
-  },
-  waveform: {
-    display: 'flex', alignItems: 'center', justifyContent: 'center',
-    gap: 2, height: 64, marginBottom: 28,
-  },
-  bar: { width: 4, borderRadius: 2, flexShrink: 0 },
-  btnRow: { display: 'flex', gap: 12, justifyContent: 'center' },
-  btnSecondary: {
-    padding: '10px 24px', borderRadius: 8, border: '0.5px solid rgba(0,0,0,0.2)',
-    background: '#FFFFFF', color: '#2C2C2A', fontSize: 14, fontWeight: 500, cursor: 'pointer',
-  },
-  btnDanger: {
-    padding: '10px 24px', borderRadius: 8, border: '0.5px solid #E24B4A',
-    background: '#FFFFFF', color: '#E24B4A', fontSize: 14, fontWeight: 500, cursor: 'pointer',
-  },
-  doneMsg: { textAlign: 'center', padding: '8px 0', color: '#2C2C2A' },
-  errorMsg: { textAlign: 'center', padding: '8px 0' },
-  popup: {
-    background: '#FFFFFF', borderRadius: 16, border: '0.5px solid rgba(0,0,0,0.1)',
-    padding: '28px 24px 20px', width: 300, textAlign: 'center',
-  },
-  popupTitle: { fontSize: 16, fontWeight: 500, color: '#2C2C2A', margin: '0 0 10px' },
-  popupDesc: { fontSize: 13, color: '#888780', lineHeight: 1.7, margin: '0 0 20px' },
-  popupBtns: { display: 'flex', gap: 8 },
-  popupCancel: {
-    flex: 1, padding: '10px', borderRadius: 8, border: '0.5px solid rgba(0,0,0,0.15)',
-    background: '#FFFFFF', color: '#444441', fontSize: 14, fontWeight: 500, cursor: 'pointer',
-  },
-  popupConfirm: {
-    flex: 1, padding: '10px', borderRadius: 8, border: 'none',
-    background: '#E24B4A', color: '#FFFFFF', fontSize: 14, fontWeight: 500, cursor: 'pointer',
-  },
-};

--- a/src/store/headerSlot.ts
+++ b/src/store/headerSlot.ts
@@ -11,6 +11,7 @@ interface EditSlot {
 interface PageHeader {
   title: string;
   hideHamburger: boolean;
+  onBack?: () => void;
 }
 
 interface HeaderSlotStore {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- 회의록 생성 선택 페이지: `setPageHeader` 적용, 카드 UI 개선 (기존 커스텀 헤더 제거)
- 녹음 페이지: 버튼 클릭 후 녹음 시작, 파란 파형 애니메이션, Tailwind 전면 리디자인
- 뒤로가기 중 경고 모달, 녹음 중지 확인 모달 추가
- `headerSlot.ts`: `onBack` 콜백 필드 추가
- `GroupHeader`: 뎁스 3+ 페이지에서 상위 목록으로 이동하는 뒤로가기 로직 개선
- **버그 수정**: `MEETING_RECORD` DB 스키마 불일치 수정 (`REG_DTM→MEETING_REG_DTM`, `STATUS` 컬럼 추가) → 회의록 탭 403 오류 해결

## Test plan
- [ ] 회의록 생성 선택 페이지 UI 확인
- [ ] 녹음 시작 버튼 클릭 후 녹음 동작 확인
- [ ] 녹음 중 뒤로가기 시 경고 모달 표시 확인
- [ ] 녹음 중지 → 확인 모달 → 업로드 → 완료 화면 흐름 확인
- [ ] 회의록 탭 클릭 시 목록 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)