### PR TITLE
fix: 미션/댓글 UX 개선 및 프로필 이미지 표시

### DIFF
--- a/src/app/[id]/home/page.tsx
+++ b/src/app/[id]/home/page.tsx
@@ -23,6 +23,7 @@ interface CommentResponse {
   cmtModDtm: string;
   newsId: number;
   memId: string;
+  userId: string;
   memNic?: string;
   userImg?: string;
 }
@@ -139,7 +140,7 @@ function Heatmap({ data }: { data: number[][] }) {
   );
 }
 
-// ─── News Card (same as main) ─────────────────────────────────────────────────
+// ─── News Card ────────────────────────────────────────────────────────────────
 
 const TARGET_BG: Record<string, string> = {
   N: 'bg-amber-100', V: 'bg-[#EBEBFF]', E: 'bg-green-100',
@@ -170,7 +171,7 @@ function getNewsLink(item: NewsResponse): string | null {
   }
 }
 
-function HomeNewsCard({ news, currentUserId }: { news: NewsResponse; currentUserId: string }) {
+function HomeNewsCard({ news, currentUserId, isLeader }: { news: NewsResponse; currentUserId: string; isLeader: boolean }) {
   const [showComments, setShowComments] = useState(false);
   const [commentText, setCommentText] = useState('');
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -187,7 +188,8 @@ function HomeNewsCard({ news, currentUserId }: { news: NewsResponse; currentUser
       const { data } = await api.get(`/api/news/${news.newsId}/comments`);
       return data.data as CommentResponse[];
     },
-    enabled: showComments && canComment,
+    enabled: canComment,
+    staleTime: 30000,
   });
 
   const addMut = useMutation({
@@ -224,7 +226,9 @@ function HomeNewsCard({ news, currentUserId }: { news: NewsResponse; currentUser
           <div className="px-3 pb-2 border-t border-zinc-100">
             <button onClick={() => setShowComments(!showComments)} className="flex items-center gap-1 text-[12px] text-zinc-400 mt-2">
               <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
-              {showComments ? '댓글 접어두기' : '댓글'}
+              {showComments
+                ? '댓글 접어두기'
+                : comments.length > 0 ? `댓글 (${comments.length})` : '댓글'}
             </button>
           </div>
           {showComments && (
@@ -233,7 +237,9 @@ function HomeNewsCard({ news, currentUserId }: { news: NewsResponse; currentUser
                 <>
                   {comments.length === 0 && <p className="text-[12px] text-zinc-400">첫 댓글을 남겨보세요.</p>}
                   {comments.map(cmt => {
-                    const isMe = cmt.memId === currentUserId;
+                    const isMe      = cmt.userId === currentUserId;
+                    const canEdit   = isMe;
+                    const canDelete = isMe || isLeader;
                     return (
                       <div key={cmt.cmtId} className="flex items-start justify-between gap-2">
                         <div className="flex items-start gap-2 flex-1 min-w-0">
@@ -254,10 +260,21 @@ function HomeNewsCard({ news, currentUserId }: { news: NewsResponse; currentUser
                             </div>
                           )}
                         </div>
-                        {isMe && editingId !== cmt.cmtId && (
-                          <div className="shrink-0 flex gap-2 pt-0.5">
-                            <button onClick={() => { setEditingId(cmt.cmtId); setEditText(cmt.cmtContent); }} className="text-[11px] text-zinc-400 hover:text-[#3B3EFF]">수정</button>
-                            <button onClick={() => delMut.mutate(cmt.cmtId)} className="text-[11px] text-zinc-400 hover:text-red-400">삭제</button>
+                        {editingId !== cmt.cmtId && (canEdit || canDelete) && (
+                          <div className="shrink-0 flex items-center gap-2 pt-0.5">
+                            {canEdit && (
+                              <button
+                                onClick={() => { setEditingId(cmt.cmtId); setEditText(cmt.cmtContent); }}
+                                className="text-[11px] text-zinc-400 hover:text-[#3B3EFF] transition-colors"
+                              >수정</button>
+                            )}
+                            {canDelete && (
+                              <button
+                                onClick={() => delMut.mutate(cmt.cmtId)}
+                                disabled={delMut.isPending}
+                                className="text-[11px] text-zinc-400 hover:text-red-400 transition-colors disabled:opacity-40"
+                              >삭제</button>
+                            )}
                           </div>
                         )}
                       </div>
@@ -291,8 +308,6 @@ function Card({ children, className = '' }: { children: React.ReactNode; classNa
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return <h2 className="text-[15px] font-bold mb-3">{children}</h2>;
 }
-
-// ─── Rank Medal Icons ─────────────────────────────────────────────────────────
 
 function RankBadge({ rank }: { rank: number }) {
   if (rank === 1) return <span className="text-base">🥇</span>;
@@ -360,7 +375,7 @@ export default function GroupHomePage() {
         <div className="space-y-2">
           {newsLoading && <div className="p-3 rounded-xl bg-zinc-50 animate-pulse h-14" />}
           {!newsLoading && news.length === 0 && <p className="text-[13px] text-zinc-400 py-2">최근 소식이 없습니다.</p>}
-          {news.map(item => <HomeNewsCard key={item.newsId} news={item} currentUserId={currentUserId} />)}
+          {news.map(item => <HomeNewsCard key={item.newsId} news={item} currentUserId={currentUserId} isLeader={isLeader} />)}
         </div>
       </section>
 
@@ -396,20 +411,20 @@ export default function GroupHomePage() {
               </Card>
             </div>
 
-            {/* 주력 미션 유형 */}
+            {/* ↓↓ 변경: 제목·설명 문구, 레이블 너비 w-16 → w-10 */}
             <Card>
-              <p className="text-[13px] font-semibold mb-1">주력 미션 유형</p>
+              <p className="text-[13px] font-semibold mb-1">미션 유형별 달성 현황</p>
               {member.typeCounts.length === 0 ? (
                 <p className="text-[12px] text-zinc-400">완료된 미션이 없습니다.</p>
               ) : (
                 <>
                   <p className="text-[11px] text-[#3B3EFF] mb-3">
-                    {member.myMemNic}님의 주력 분야는 <span className="font-bold">{member.topTypeLabel}</span> 미션입니다.
+                    {member.myMemNic}님이 가장 많이 달성한 유형은 <span className="font-bold">{member.topTypeLabel}</span> 미션입니다.
                   </p>
                   <div className="space-y-2">
                     {member.typeCounts.map(tc => (
                       <div key={tc.type} className="flex items-center gap-2">
-                        <span className="text-[12px] text-zinc-600 w-16 shrink-0">{tc.label}</span>
+                        <span className="text-[12px] text-zinc-600 w-10 shrink-0">{tc.label}</span>
                         <div className="flex-1 h-2 bg-zinc-200 rounded-full overflow-hidden">
                           <div className="h-full rounded-full bg-[#3B3EFF]"
                             style={{ width: `${(tc.count / maxTypeCount) * 100}%` }} />

--- a/src/app/[id]/missions/[missionId]/submissions/[submissionId]/page.tsx
+++ b/src/app/[id]/missions/[missionId]/submissions/[submissionId]/page.tsx
@@ -19,6 +19,7 @@ interface VerifyDetail {
   missionId: number;
   memId: string;
   memNic: string;
+  userImg: string | null;
   rejectReason: string | null;
   fileKeys: string[];
 }
@@ -137,8 +138,11 @@ export default function SubmissionDetailPage() {
 
       {/* 제출자 + AI 결과 */}
       <div className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3">
-        <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
-          <span className="text-[13px] font-bold text-white">{(detail?.memNic ?? memberName)[0]}</span>
+        <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0 overflow-hidden">
+          {detail?.userImg
+            ? <img src={detail.userImg} alt={detail.memNic} className="w-full h-full object-cover" />
+            : <span className="text-[13px] font-bold text-white">{(detail?.memNic ?? memberName)[0]}</span>
+          }
         </div>
         <div className="flex-1">
           <p className="text-[13px] font-semibold text-zinc-800">{detail?.memNic ?? memberName}</p>

--- a/src/app/[id]/missions/[missionId]/submissions/page.tsx
+++ b/src/app/[id]/missions/[missionId]/submissions/page.tsx
@@ -23,6 +23,7 @@ const STATUS_LABEL: Record<string, { text: string; color: string; bg: string }> 
 interface VerifyItem {
   verifyId: number;
   memNic: string;
+  userImg: string | null;
   verifyRegDtm: string;
   verifyState: string;
   aiRejectYn: string | null;
@@ -150,8 +151,11 @@ export default function SubmissionsPage() {
           return (
             <button key={s.verifyId} onClick={() => router.push(href)}
               className="bg-white rounded-xl px-4 py-3.5 flex items-center gap-3 text-left w-full">
-              <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0">
-                <span className="text-[13px] font-bold text-white">{s.memNic[0]}</span>
+              <div className="w-9 h-9 rounded-full bg-[#C4B5FD] flex items-center justify-center shrink-0 overflow-hidden">
+                {s.userImg
+                  ? <img src={s.userImg} alt={s.memNic} className="w-full h-full object-cover" />
+                  : <span className="text-[13px] font-bold text-white">{s.memNic?.[0] ?? '?'}</span>
+                }
               </div>
               <div className="flex-1 min-w-0">
                 <p className="text-[13px] font-semibold text-zinc-900">{s.memNic}</p>

--- a/src/app/[id]/missions/page.tsx
+++ b/src/app/[id]/missions/page.tsx
@@ -2,157 +2,247 @@
 
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
 
-interface MissionResponse {
+type ScopeTab = '전체' | '공통' | '개인';
+type StatusFilter = '전체' | '진행 중' | '완료' | '만료';
+type UserStatus = 'available' | 'pending' | 'completed' | 'rejected' | 'expired';
+
+interface MemberMe { memId: string; memRole: string; memState: string; }
+
+interface MemberInfo {
+  memId: string;
+  memNic: string;
+  imgFileKey: string | null;
+}
+
+interface MissionData {
   missionId: number;
   missionTitle: string;
   missionContent: string;
-  missionType: string;
-  verifyPrompt: string;
+  missionType: string; // 'A'(공통) | 'P'(개인)
+  verifyPrompt: string | null;
   missionStartDtm: string;
   missionEndDtm: string;
   teamId: string;
+  memIds: string[];
+  fileKeys: string[];
+  memberInfos: MemberInfo[]; // 개인 미션 대상자 정보
 }
 
-interface MemberResponse {
-  memRole: string;
-  memState: string;
+const SCOPE_COLOR: Record<string, string> = { 공통: '#FF9E6A', 개인: '#E5638C' };
+
+function getScope(missionType: string): '공통' | '개인' {
+  return missionType === 'P' ? '개인' : '공통';
 }
 
-const INPUT_CLS = 'w-full border border-zinc-200 rounded-lg px-3 py-2.5 text-[14px] text-zinc-800 placeholder:text-zinc-300 outline-none focus:border-[#3B3EFF] transition-colors bg-white';
-
-function getMissionHref(mission: MissionResponse, isLeader: boolean, id: string): string {
-  const authType = mission.missionType === 'I' ? 'AI인증' : '수동인증';
-  const subtitle = `${mission.missionStartDtm?.slice(0, 10)} ~ ${mission.missionEndDtm?.slice(0, 10)}`;
-  const params = new URLSearchParams({ authType, scope: '공통', title: mission.missionTitle, subtitle });
-  const base = `/${id}/missions/${mission.missionId}`;
-  return isLeader ? `${base}/submissions?${params}` : `${base}/pending?${params}`;
+function getDeadlineText(endDtm: string): string | null {
+  const end = new Date(endDtm.replace(' ', 'T'));
+  const diff = end.getTime() - Date.now();
+  if (diff <= 0) return null;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return `${mins}분`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간`;
+  return `${Math.floor(hours / 24)}일`;
 }
 
-function getDaysLeft(endDtm: string): number | null {
-  const diff = Math.ceil((new Date(endDtm).getTime() - Date.now()) / 86400000);
-  return diff > 0 ? diff : null;
+function deadlineColor(dl: string): string {
+  if (dl.includes('분') || dl.includes('시간')) return 'text-[#f97316]';
+  return Number(dl.replace(/\D/g, '')) <= 3 ? 'text-[#f97316]' : 'text-[#3B3EFF]';
 }
 
-function MissionTypeLabel({ type }: { type: string }) {
-  const map: Record<string, { label: string; cls: string }> = {
-    T: { label: '텍스트', cls: 'bg-blue-50 text-blue-600' },
-    I: { label: '이미지', cls: 'bg-purple-50 text-purple-600' },
-    B: { label: '텍스트+이미지', cls: 'bg-indigo-50 text-indigo-600' },
-  };
-  const info = map[type] ?? { label: type, cls: 'bg-zinc-100 text-zinc-500' };
+function Badges({ scope }: { scope: '공통' | '개인' }) {
   return (
-    <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${info.cls}`}>
-      {info.label}
-    </span>
+    <div className="flex gap-1 mb-1">
+      <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full text-white"
+        style={{ backgroundColor: SCOPE_COLOR[scope] }}>{scope}</span>
+    </div>
   );
 }
 
-function CreateModal({
-  teamId,
-  onClose,
-  onCreated,
-}: {
-  teamId: string;
-  onClose: () => void;
-  onCreated: () => void;
-}) {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [missionType, setMissionType] = useState('T');
-  const [verifyPrompt, setVerifyPrompt] = useState('');
-  const [startDtm, setStartDtm] = useState(new Date().toISOString().slice(0, 16));
-  const [endDtm, setEndDtm] = useState('');
-
-  const createMutation = useMutation({
-    mutationFn: () =>
-      api.post('/api/missions', {
-        missionTitle: title.trim(),
-        missionContent: content.trim(),
-        missionType,
-        verifyPrompt: verifyPrompt.trim(),
-        missionStartDtm: startDtm.replace('T', ' ') + ':00',
-        missionEndDtm: endDtm.replace('T', ' ') + ':00',
-        teamId,
-      }),
-    onSuccess: () => onCreated(),
-  });
-
-  const isDisabled = !title.trim() || !content.trim() || !endDtm;
-
+/** 개인 미션 대상자 아바타 목록 */
+function MemberAvatars({ members }: { members: MemberInfo[] }) {
+  if (!members || members.length === 0) return null;
+  const show = members.slice(0, 3);
+  const rest = members.length - show.length;
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50">
-      <div className="bg-white rounded-t-2xl w-full max-w-[390px] p-5 pb-8 flex flex-col gap-4">
-        <div className="flex items-center justify-between mb-1">
-          <h3 className="text-[16px] font-bold text-zinc-900">미션 생성</h3>
-          <button onClick={onClose} className="w-7 h-7 rounded-full bg-zinc-100 flex items-center justify-center">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+    <div className="flex items-center gap-1 mt-1.5">
+      <div className="flex -space-x-1.5">
+        {show.map((m) => (
+          <div key={m.memId}
+            className="w-5 h-5 rounded-full border border-white bg-[#C4B5FD] overflow-hidden shrink-0 flex items-center justify-center">
+            {m.imgFileKey
+              ? <img src={m.imgFileKey} alt={m.memNic} className="w-full h-full object-cover" />
+              : <span className="text-[8px] font-bold text-white leading-none">{m.memNic[0]}</span>}
+          </div>
+        ))}
+        {rest > 0 && (
+          <div className="w-5 h-5 rounded-full border border-white bg-zinc-300 flex items-center justify-center">
+            <span className="text-[8px] font-bold text-zinc-600">+{rest}</span>
+          </div>
+        )}
+      </div>
+      <span className="text-[10px] text-zinc-400 truncate max-w-[120px]">
+        {show.map(m => m.memNic).join(', ')}{rest > 0 ? ` 외 ${rest}명` : ''}
+      </span>
+    </div>
+  );
+}
+
+function DeleteMissionPopup({ title, onConfirm, onCancel, isPending }: {
+  title: string; onConfirm: () => void; onCancel: () => void; isPending: boolean;
+}) {
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/40 z-40" onClick={onCancel} />
+      <div className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-white rounded-2xl shadow-xl w-[280px] overflow-hidden">
+        <div className="px-6 pt-6 pb-5 text-center">
+          <div className="w-11 h-11 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-3">
+            <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="#ef4444" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
             </svg>
+          </div>
+          <p className="text-[15px] font-bold text-zinc-900 mb-1">미션을 삭제할까요?</p>
+          <p className="text-[12px] text-zinc-400 leading-relaxed">
+            <span className="font-medium text-zinc-600">&ldquo;{title}&rdquo;</span><br />
+            모든 인증 내역도 함께 삭제됩니다.
+          </p>
+        </div>
+        <div className="flex border-t border-zinc-100">
+          <button onClick={onCancel} className="flex-1 py-3.5 text-[14px] font-medium text-zinc-500 border-r border-zinc-100">취소</button>
+          <button onClick={onConfirm} disabled={isPending} className="flex-1 py-3.5 text-[14px] font-semibold text-red-500 disabled:opacity-50">
+            {isPending ? '삭제 중...' : '삭제'}
           </button>
         </div>
+      </div>
+    </>
+  );
+}
 
-        <div>
-          <label className="block text-[12px] font-medium text-zinc-500 mb-1">미션 제목</label>
-          <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="예) 매일 30분 운동하기" className={INPUT_CLS} />
-        </div>
-
-        <div>
-          <label className="block text-[12px] font-medium text-zinc-500 mb-1">미션 내용</label>
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="미션에 대한 설명을 입력하세요"
-            rows={2}
-            className={`${INPUT_CLS} resize-none`}
-          />
-        </div>
-
-        <div>
-          <label className="block text-[12px] font-medium text-zinc-500 mb-1.5">인증 방식</label>
-          <div className="flex gap-2">
-            {[['T', '텍스트'], ['I', '이미지'], ['B', '텍스트+이미지']].map(([val, label]) => (
-              <button
-                key={val}
-                onClick={() => setMissionType(val)}
-                className={`flex-1 py-1.5 rounded-lg text-[12px] font-medium border transition-colors ${missionType === val ? 'bg-[#3B3EFF] border-[#3B3EFF] text-white' : 'bg-white border-zinc-200 text-zinc-500'}`}
-              >
-                {label}
+function MemberMissionCard({ m, deadline, userStatus, onVerify, onViewPending }: {
+  m: MissionData; deadline: string | null; userStatus: UserStatus;
+  onVerify: () => void; onViewPending: () => void;
+}) {
+  const scope = getScope(m.missionType);
+  const isDone = userStatus === 'completed' || userStatus === 'rejected' || userStatus === 'expired';
+  return (
+    <div className="bg-white rounded-lg px-4 py-3 flex items-center gap-3">
+      <div className={`w-10 h-10 rounded-full shrink-0 ${isDone ? 'bg-zinc-300' : 'bg-zinc-200'}`} />
+      <div className="flex-1 min-w-0">
+        <Badges scope={scope} />
+        <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.missionTitle}</p>
+        <p className="text-[11px] text-zinc-400 mt-1 truncate">{m.missionContent}</p>
+        {m.missionType === 'P' && <MemberAvatars members={m.memberInfos ?? []} />}
+      </div>
+      <div className="shrink-0 flex flex-col items-end gap-2">
+        {userStatus === 'available' && (
+          <>
+            {deadline
+              ? <p className="text-[12px]"><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(deadline)}>{deadline}</span></p>
+              : <span className="text-[12px] text-zinc-400">마감</span>}
+            {deadline && (
+              <button onClick={onVerify} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M5 12h14M12 5l7 7-7 7" /></svg>
+                인증하기
               </button>
-            ))}
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-[12px] font-medium text-zinc-500 mb-1">AI 검증 기준 <span className="font-normal text-zinc-300">(선택)</span></label>
-          <input value={verifyPrompt} onChange={(e) => setVerifyPrompt(e.target.value)} placeholder="예) 운동 중인 모습이 사진에 있어야 함" className={INPUT_CLS} />
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="block text-[12px] font-medium text-zinc-500 mb-1">시작일시</label>
-            <input type="datetime-local" value={startDtm} onChange={(e) => setStartDtm(e.target.value)} className={INPUT_CLS} />
-          </div>
-          <div>
-            <label className="block text-[12px] font-medium text-zinc-500 mb-1">종료일시</label>
-            <input type="datetime-local" value={endDtm} onChange={(e) => setEndDtm(e.target.value)} className={INPUT_CLS} />
-          </div>
-        </div>
-
-        {createMutation.isError && (
-          <p className="text-[12px] text-red-500">미션 생성에 실패했습니다.</p>
+            )}
+          </>
         )}
+        {userStatus === 'pending' && (
+          <>
+            {deadline
+              ? <p className="text-[12px]"><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(deadline)}>{deadline}</span></p>
+              : <span className="text-[12px] text-zinc-400">마감</span>}
+            <button onClick={onViewPending} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" /></svg>
+              승인 대기
+            </button>
+          </>
+        )}
+        {userStatus === 'rejected' && (
+          <>
+            <span className="text-[12px] text-zinc-400">마감</span>
+            <button onClick={onViewPending} className="text-[12px] font-semibold text-red-400 bg-white border border-red-200 rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M18 6L6 18M6 6l12 12" /></svg>
+              인증 반려
+            </button>
+          </>
+        )}
+        {userStatus === 'completed' && (
+          <>
+            <span className="text-[12px] text-zinc-400">마감</span>
+            <button onClick={onViewPending} className="text-[12px] font-medium text-zinc-400 bg-zinc-100 rounded-lg px-3.5 py-1.5 flex items-center gap-1 whitespace-nowrap">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}><path d="M5 13l4 4L19 7" /></svg>
+              인증 완료
+            </button>
+          </>
+        )}
+        {userStatus === 'expired' && (
+          <span className="text-[12px] font-medium text-zinc-400 bg-zinc-100 rounded-lg px-3.5 py-1.5 whitespace-nowrap">
+            기간 만료
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
 
-        <button
-          disabled={isDisabled || createMutation.isPending}
-          onClick={() => createMutation.mutate()}
-          className={`w-full py-3 rounded-xl text-[15px] font-semibold transition-colors ${isDisabled || createMutation.isPending ? 'bg-zinc-300 text-white' : 'bg-[#3B3EFF] text-white'}`}
-        >
-          {createMutation.isPending ? '생성 중...' : '미션 생성'}
+function LeaderCard({ m, onViewSubmissions, onEdit, onDelete }: {
+  m: MissionData; onViewSubmissions: () => void; onEdit: () => void; onDelete: () => void;
+}) {
+  const scope = getScope(m.missionType);
+  const deadline = getDeadlineText(m.missionEndDtm);
+  return (
+    <div className="bg-white rounded-lg px-4 py-3">
+      <div className="flex items-center gap-3">
+        <div className="w-10 h-10 rounded-full bg-zinc-200 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <Badges scope={scope} />
+          <p className="text-[12px] font-medium text-zinc-800 leading-tight">{m.missionTitle}</p>
+          <p className="text-[11px] text-zinc-400 mt-1 truncate">{m.missionContent}</p>
+          {m.missionType === 'P' && <MemberAvatars members={m.memberInfos ?? []} />}
+        </div>
+        <div className="shrink-0 flex flex-col items-end gap-2">
+          {deadline
+            ? <p className="text-[12px]"><span className="text-zinc-800">마감까지 </span><span className={deadlineColor(deadline)}>{deadline}</span></p>
+            : <span className="text-[12px] text-zinc-400">마감</span>}
+          <button onClick={onViewSubmissions} className="text-[12px] font-semibold text-white bg-[#3B3EFF] rounded-lg px-3.5 py-1.5 whitespace-nowrap">
+            제출 확인
+          </button>
+        </div>
+      </div>
+      {/* 수정/삭제 버튼 */}
+      <div className="flex gap-2 mt-3 pt-3 border-t border-zinc-100">
+        <button onClick={onEdit}
+          className="flex-1 py-1.5 rounded-lg border border-zinc-200 text-[12px] font-medium text-zinc-500 flex items-center justify-center gap-1">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+          </svg>
+          수정
+        </button>
+        <button onClick={onDelete}
+          className="flex-1 py-1.5 rounded-lg border border-red-100 text-[12px] font-medium text-red-400 flex items-center justify-center gap-1">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+          </svg>
+          삭제
         </button>
       </div>
+    </div>
+  );
+}
+
+function StatusBar({ value, onChange }: { value: StatusFilter; onChange: (v: StatusFilter) => void }) {
+  return (
+    <div className="flex items-center justify-center mb-3">
+      {(['전체', '진행 중', '완료', '만료'] as StatusFilter[]).map((f, i) => (
+        <div key={f} className="flex items-center">
+          <button onClick={() => onChange(f)} className={`text-[13px] px-2 ${value === f ? 'font-semibold text-zinc-900' : 'text-zinc-400'}`}>{f}</button>
+          {i < 3 && <span className="text-zinc-300 text-[13px]">|</span>}
+        </div>
+      ))}
     </div>
   );
 }
@@ -161,134 +251,259 @@ export default function MissionsPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const [showCreate, setShowCreate] = useState(false);
-  const [tab, setTab] = useState<'전체' | '진행중' | '종료'>('전체');
+  const [scopeTab,         setScopeTab]         = useState<ScopeTab>('전체');
+  const [leaderScopeFilter, setLeaderScopeFilter] = useState<ScopeTab>('전체');
+  const [statusFilter,     setStatusFilter]     = useState<StatusFilter>('전체');
+  const [execMode,         setExecMode]         = useState(false);
+  const [deleteTarget,     setDeleteTarget]     = useState<MissionData | null>(null);
 
-  const { data: myMembership } = useQuery({
-    queryKey: ['members', 'me', id],
+  const { data: myMember } = useQuery<MemberMe>({
+    queryKey: ['memberMe', id],
     queryFn: async () => {
       const { data } = await api.get(`/api/members/me?teamId=${id}`);
-      return data.data as MemberResponse;
+      return data.data;
     },
     enabled: !!id,
   });
 
-  const isLeader = myMembership?.memRole === 'L' && myMembership?.memState === 'A';
+  const isLeader = myMember?.memRole === 'L' && myMember?.memState === 'A';
 
-  const { data: missions = [], isLoading } = useQuery({
+  const { data: missions = [], isLoading: missionsLoading } = useQuery<MissionData[]>({
     queryKey: ['missions', id],
     queryFn: async () => {
       const { data } = await api.get(`/api/missions?teamId=${id}`);
-      return data.data as MissionResponse[];
+      return data.data ?? [];
     },
     enabled: !!id,
   });
 
   const deleteMutation = useMutation({
     mutationFn: (missionId: number) => api.delete(`/api/missions/${missionId}`),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['missions', id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['missions', id] });
+      setDeleteTarget(null);
+    },
+    onError: () => alert('삭제에 실패했습니다.'),
   });
 
-  const filtered = missions.filter((m) => {
-    const active = getDaysLeft(m.missionEndDtm) !== null;
-    if (tab === '진행중') return active;
-    if (tab === '종료') return !active;
+  // 멤버 시점 (수행 모드 포함)
+  const submissionQueries = useQueries({
+    queries: missions.map((m) => ({
+      queryKey: ['mySubmission', m.missionId],
+      queryFn: async (): Promise<{ verifyState: string } | null> => {
+        try {
+          const { data } = await api.get(`/api/missions/${m.missionId}/submissions/me`);
+          return data.data ?? null;
+        } catch { return null; }
+      },
+      retry: false,
+      enabled: (!isLeader || execMode) && !!id && missions.length > 0,
+    })),
+  });
+
+  const getUserStatus = (idx: number): UserStatus => {
+    const q = submissionQueries[idx];
+    const dl = getDeadlineText(missions[idx]?.missionEndDtm ?? '');
+    if (!q || q.isLoading) return dl ? 'available' : 'expired';
+    if (!q.data) return dl ? 'available' : 'expired';
+    const state = q.data.verifyState;
+    if (state === 'A' || state === 'F') return 'completed';
+    if (state === 'R') return 'rejected';
+    return 'pending';
+  };
+
+  const missionParams = (m: MissionData) => {
+    const params = new URLSearchParams({
+      authType:      'AI인증',
+      scope:         getScope(m.missionType),
+      title:         m.missionTitle,
+      subtitle:      m.missionContent.substring(0, 50),
+      verifyPrompt:  m.verifyPrompt ?? '',
+    });
+    return `?${params.toString()}`;
+  };
+
+  // 멤버 뷰 필터
+  const memberMissions = missions
+    .map((m, idx) => ({ m, idx }))
+    .filter(({ m, idx }) => {
+      // 리더가 수행 모드일 때: 개인 미션(P)은 본인이 대상자인 것만 표시
+      if (execMode && isLeader && m.missionType === 'P') {
+        if (!myMember?.memId || !m.memIds.includes(myMember.memId)) return false;
+      }
+      const scope = getScope(m.missionType);
+      if (scopeTab !== '전체' && scope !== scopeTab) return false;
+      const userStatus = getUserStatus(idx);
+      if (statusFilter === '진행 중') return userStatus === 'available' || userStatus === 'pending';
+      if (statusFilter === '완료') return userStatus === 'completed' || userStatus === 'rejected';
+      if (statusFilter === '만료') return userStatus === 'expired';
+      return true;
+    });
+
+  // 리더 관리 뷰 필터
+  const leaderFilteredMissions = missions.filter((m) => {
+    const scope = getScope(m.missionType);
+    if (leaderScopeFilter !== '전체' && scope !== leaderScopeFilter) return false;
+    const dl = getDeadlineText(m.missionEndDtm);
+    if (statusFilter === '진행 중') return !!dl;
+    if (statusFilter === '완료' || statusFilter === '만료') return !dl;
     return true;
   });
 
-  return (
-    <div className="flex flex-col min-h-full">
-      {showCreate && (
-        <CreateModal
-          teamId={id}
-          onClose={() => setShowCreate(false)}
-          onCreated={() => {
-            queryClient.invalidateQueries({ queryKey: ['missions', id] });
-            setShowCreate(false);
-          }}
-        />
-      )}
-
-      <div className="flex border-b border-zinc-200 -mx-4 sticky top-0 z-10 bg-white">
-        {(['전체', '진행중', '종료'] as const).map((t) => (
-          <button
-            key={t}
-            onClick={() => setTab(t)}
-            className={`flex-1 flex justify-center text-[13px] font-medium transition-colors whitespace-nowrap ${tab === t ? 'text-zinc-900' : 'text-zinc-400'}`}
-          >
-            <span className={`inline-block py-2.5 -mb-px ${tab === t ? 'border-b-2 border-zinc-900' : ''}`}>
-              {t}
-            </span>
-          </button>
-        ))}
+  if (missionsLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-20">
+        <p className="text-[13px] text-zinc-400">불러오는 중...</p>
       </div>
+    );
+  }
 
-      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-28">
-        {isLoading && <p className="text-center text-[13px] text-zinc-400 py-10">불러오는 중...</p>}
-        {!isLoading && filtered.length === 0 && (
-          <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
-        )}
+  /* ── 모드 토글 (리더 전용) ── */
+  const ModeToggle = () => (
+    <div className="flex items-center bg-zinc-100 rounded-full p-0.5 shrink-0 mr-3">
+      <button
+        onClick={() => setExecMode(false)}
+        className={`px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all whitespace-nowrap ${
+          !execMode ? 'bg-white text-zinc-900 shadow-sm' : 'text-zinc-400'
+        }`}
+      >
+        관리
+      </button>
+      <button
+        onClick={() => setExecMode(true)}
+        className={`px-2.5 py-1 rounded-full text-[11px] font-semibold transition-all whitespace-nowrap ${
+          execMode ? 'bg-white text-zinc-900 shadow-sm' : 'text-zinc-400'
+        }`}
+      >
+        수행
+      </button>
+    </div>
+  );
 
-        <div className="space-y-3">
-          {filtered.map((mission) => {
-            const daysLeft = getDaysLeft(mission.missionEndDtm);
-            const isActive = daysLeft !== null;
-
-            return (
-              <div
-                key={mission.missionId}
-                onClick={() => router.push(getMissionHref(mission, isLeader, id))}
-                className="bg-white rounded-xl px-4 py-4 cursor-pointer active:scale-[0.99] transition-transform"
-              >
-                <div className="flex items-start justify-between gap-3 mb-2">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1.5 mb-1.5 flex-wrap">
-                      <MissionTypeLabel type={mission.missionType} />
-                      {isActive ? (
-                        <span className="text-[11px] font-semibold text-[#3B3EFF]">D-{daysLeft}</span>
-                      ) : (
-                        <span className="text-[11px] font-semibold text-zinc-400">종료</span>
-                      )}
-                    </div>
-                    <p className="text-[15px] font-bold text-zinc-900">{mission.missionTitle}</p>
-                  </div>
-                  {isLeader && (
-                    <button
-                      onClick={(e) => { e.stopPropagation(); deleteMutation.mutate(mission.missionId); }}
-                      disabled={deleteMutation.isPending}
-                      className="shrink-0 w-7 h-7 rounded-full bg-zinc-100 flex items-center justify-center text-zinc-400 hover:bg-red-50 hover:text-red-400 transition-colors"
-                    >
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
-                <p className="text-[13px] text-zinc-500 leading-relaxed mb-3">{mission.missionContent}</p>
-                <div className="flex items-center justify-between text-[11px] text-zinc-400">
-                  <span>{mission.missionStartDtm?.slice(0, 10)} ~ {mission.missionEndDtm?.slice(0, 10)}</span>
-                  <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="#d4d4d8" strokeWidth={2.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
-                  </svg>
-                </div>
-              </div>
-            );
-          })}
+  /* ── 리더 + 관리 모드 ── */
+  if (isLeader && !execMode) {
+    return (
+      <div className="flex flex-col min-h-full">
+        {/* 헤더: 상태 탭(1차) + 모드 토글 */}
+        <div className="sticky top-0 z-10 bg-white -mx-4">
+          <div className="flex border-b border-zinc-200 items-center">
+            {(['전체', '진행 중', '완료'] as StatusFilter[]).map((t) => (
+              <button key={t} onClick={() => setStatusFilter(t)}
+                className={`flex-1 flex justify-center text-[13px] font-medium transition-colors ${statusFilter === t ? 'text-zinc-900' : 'text-zinc-400'}`}>
+                <span className={`inline-block py-2.5 -mb-px ${statusFilter === t ? 'border-b-2 border-zinc-900' : ''}`}>{t}</span>
+              </button>
+            ))}
+            <ModeToggle />
+          </div>
+          {/* 범위 필터 (2차) */}
+          <div className="flex gap-2 px-4 py-2 border-b border-zinc-100 bg-white">
+            {(['전체', '공통', '개인'] as ScopeTab[]).map((s) => (
+              <button key={s} onClick={() => setLeaderScopeFilter(s)}
+                className={`text-[12px] px-3 py-1 rounded-full font-medium transition-all ${
+                  leaderScopeFilter === s ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-500'
+                }`}>
+                {s}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {isLeader && (
-          <button
-            onClick={() => setShowCreate(true)}
-            className="fixed bottom-6 bg-[#3B3EFF] text-white text-[13px] font-semibold px-4 py-2.5 rounded-full shadow-lg flex items-center gap-1.5"
-            style={{ right: 'max(1rem, calc((100vw - 390px) / 2 + 1rem))' }}
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth={2.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
-            </svg>
-            미션 생성
-          </button>
+        <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
+          {leaderFilteredMissions.length === 0
+            ? <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
+            : leaderFilteredMissions.map((m) => (
+              <LeaderCard
+                key={m.missionId}
+                m={m}
+                onViewSubmissions={() => router.push(`/${id}/missions/${m.missionId}/submissions${missionParams(m)}`)}
+                onEdit={() => router.push(`/${id}/missions/${m.missionId}/edit`)}
+                onDelete={() => setDeleteTarget(m)}
+              />
+            ))
+          }
+        </div>
+
+        {/* 미션 생성 버튼 */}
+        <button
+          onClick={() => router.push(`/${id}/missions/new`)}
+          className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
+          style={{ right: 'calc(50% - 195px + 24px)' }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+
+        {deleteTarget && (
+          <DeleteMissionPopup
+            title={deleteTarget.missionTitle}
+            onConfirm={() => deleteMutation.mutate(deleteTarget.missionId)}
+            onCancel={() => setDeleteTarget(null)}
+            isPending={deleteMutation.isPending}
+          />
         )}
       </div>
+    );
+  }
+
+  /* ── 멤버 뷰 (or 리더 수행모드) ── */
+  return (
+    <div className="flex flex-col min-h-full">
+      {/* 헤더: 범위 탭 + 모드 토글(리더만) */}
+      <div className="sticky top-0 z-10 bg-white -mx-4">
+        <div className="flex border-b border-zinc-200 items-center">
+          {(['전체', '공통', '개인'] as ScopeTab[]).map((t) => (
+            <button key={t} onClick={() => setScopeTab(t)}
+              className={`flex-1 flex justify-center text-[13px] font-medium transition-colors ${scopeTab === t ? 'text-zinc-900' : 'text-zinc-400'}`}>
+              <span className={`inline-block py-2.5 -mb-px ${scopeTab === t ? 'border-b-2 border-zinc-900' : ''}`}>{t}</span>
+            </button>
+          ))}
+          {isLeader && <ModeToggle />}
+        </div>
+      </div>
+
+      <div className="flex-1 -mx-4 -mb-5 bg-zinc-100 px-4 pt-4 pb-24 space-y-3">
+        {isLeader && execMode && (
+          <div className="flex items-center gap-2 bg-[#EBEBFF] rounded-xl px-3 py-2">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#3B3EFF" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            <p className="text-[12px] text-[#3B3EFF] font-medium">수행 모드: 멤버 시점으로 미션을 확인합니다.</p>
+          </div>
+        )}
+        <StatusBar value={statusFilter} onChange={setStatusFilter} />
+        {memberMissions.length === 0
+          ? <p className="text-center text-[13px] text-zinc-400 py-10">미션이 없습니다.</p>
+          : memberMissions.map(({ m, idx }) => {
+            const deadline = getDeadlineText(m.missionEndDtm);
+            const userStatus = getUserStatus(idx);
+            const params = missionParams(m);
+            return (
+              <MemberMissionCard
+                key={m.missionId}
+                m={m}
+                deadline={deadline}
+                userStatus={userStatus}
+                onVerify={() => router.push(`/${id}/missions/${m.missionId}/verify${params}`)}
+                onViewPending={() => router.push(`/${id}/missions/${m.missionId}/pending${params}`)}
+              />
+            );
+          })
+        }
+      </div>
+
+      {/* 리더는 수행모드에서도 생성 버튼 표시 */}
+      {isLeader && (
+        <button
+          onClick={() => router.push(`/${id}/missions/new`)}
+          className="fixed bottom-[80px] w-12 h-12 bg-[#3B3EFF] rounded-full flex items-center justify-center shadow-lg z-20"
+          style={{ right: 'calc(50% - 195px + 24px)' }}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/main/page.tsx
+++ b/src/app/main/page.tsx
@@ -262,6 +262,7 @@ interface CommentResponse {
   cmtModDtm: string;
   newsId: number;
   memId: string;
+  userId: string;
   memNic?: string;
   userImg?: string;
 }
@@ -329,8 +330,8 @@ function getNewsLink(item: NewsResponse): string | null {
 function HomeNewsCard({ news, teamName, currentUserId }: { news: NewsResponse; teamName?: string; currentUserId: string }) {
   const [showComments, setShowComments] = useState(false);
   const [commentText, setCommentText] = useState('');
-  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
-  const [editCommentText, setEditCommentText] = useState('');
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editText, setEditText] = useState('');
   const queryClient = useQueryClient();
 
   const canComment = news.targetType === 'M' || news.targetType === 'A';
@@ -343,27 +344,20 @@ function HomeNewsCard({ news, teamName, currentUserId }: { news: NewsResponse; t
       const { data } = await api.get(`/api/news/${news.newsId}/comments`);
       return data.data as CommentResponse[];
     },
-    enabled: showComments && canComment,
+    enabled: canComment,
+    staleTime: 30000,
   });
 
-  const addCommentMutation = useMutation({
-    mutationFn: () =>
-      api.post('/api/news/comments', { newsId: news.newsId, cmtContent: commentText.trim() }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', news.newsId] });
-      setCommentText('');
-    },
+  const addMut = useMutation({
+    mutationFn: () => api.post('/api/news/comments', { newsId: news.newsId, cmtContent: commentText.trim() }),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['comments', news.newsId] }); setCommentText(''); },
   });
-
-  const updateCommentMutation = useMutation({
-    mutationFn: ({ cmtId, cmtContent }: { cmtId: number, cmtContent: string }) => api.put(`/api/news/comments/${cmtId}`, { cmtContent }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['comments', news.newsId] });
-      setEditingCommentId(null);
-    },
+  const editMut = useMutation({
+    mutationFn: ({ cmtId, cmtContent }: { cmtId: number; cmtContent: string }) =>
+      api.put(`/api/news/comments/${cmtId}`, { cmtContent }),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['comments', news.newsId] }); setEditingId(null); },
   });
-
-  const deleteCommentMutation = useMutation({
+  const delMut = useMutation({
     mutationFn: (cmtId: number) => api.delete(`/api/news/comments/${cmtId}`),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['comments', news.newsId] }),
   });
@@ -410,7 +404,9 @@ function HomeNewsCard({ news, teamName, currentUserId }: { news: NewsResponse; t
               <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
               </svg>
-              {showComments ? '댓글 접어두기' : '댓글'}
+              {showComments
+                ? '댓글 접어두기'
+                : comments.length > 0 ? `댓글 (${comments.length})` : '댓글'}
             </button>
           </div>
           {showComments && (
@@ -419,67 +415,78 @@ function HomeNewsCard({ news, teamName, currentUserId }: { news: NewsResponse; t
                 <p className="text-[12px] text-zinc-400">불러오는 중...</p>
               ) : (
                 <>
-                  {comments.length === 0 && (
-                    <p className="text-[12px] text-zinc-400">첫 댓글을 남겨보세요.</p>
-                  )}
+                  {comments.length === 0 && <p className="text-[12px] text-zinc-400">첫 댓글을 남겨보세요.</p>}
                   {comments.map((cmt) => {
-                    const isMyComment = cmt.memId === currentUserId;
+                    const isMe = cmt.userId === currentUserId;
                     return (
-                    <div key={cmt.cmtId} className="flex items-start justify-between gap-2">
-                      <div className="flex items-start gap-2 flex-1 min-w-0">
-                        <div className="w-6 h-6 rounded-full bg-zinc-200 shrink-0 flex items-center justify-center text-[10px] text-zinc-500 font-medium overflow-hidden">
-                          {cmt.userImg && cmt.userImg !== 'default' ? (
-                            <img src={cmt.userImg} alt="Profile" className="w-full h-full object-cover" />
+                      <div key={cmt.cmtId} className="flex items-start justify-between gap-2">
+                        <div className="flex items-start gap-2 flex-1 min-w-0">
+                          <div className="w-6 h-6 rounded-full bg-zinc-200 shrink-0 flex items-center justify-center text-[10px] text-zinc-500 font-medium overflow-hidden">
+                            {cmt.userImg && cmt.userImg !== 'default'
+                              ? <img src={cmt.userImg} alt="" className="w-full h-full object-cover" />
+                              : (cmt.memNic || cmt.memId)?.slice(0, 1) || '?'}
+                          </div>
+                          {editingId === cmt.cmtId ? (
+                            <div className="flex-1 flex flex-col gap-1.5">
+                              <input
+                                value={editText}
+                                onChange={e => setEditText(e.target.value)}
+                                onKeyDown={e => {
+                                  if (e.key === 'Enter' && editText.trim()) editMut.mutate({ cmtId: cmt.cmtId, cmtContent: editText.trim() });
+                                  if (e.key === 'Escape') setEditingId(null);
+                                }}
+                                className="flex-1 border border-[#3B3EFF] rounded-lg px-2.5 py-1.5 text-[12px] outline-none bg-white"
+                                autoFocus
+                              />
+                              <div className="flex gap-2">
+                                <button
+                                  disabled={!editText.trim() || editMut.isPending}
+                                  onClick={() => editMut.mutate({ cmtId: cmt.cmtId, cmtContent: editText.trim() })}
+                                  className="text-[11px] font-semibold text-[#3B3EFF] disabled:opacity-40"
+                                >저장</button>
+                                <button onClick={() => setEditingId(null)} className="text-[11px] text-zinc-400">취소</button>
+                              </div>
+                            </div>
                           ) : (
-                            (cmt.memNic || cmt.memId)?.slice(0, 1) || '?'
+                            <div className="flex-1 min-w-0">
+                              <p className="text-[11px] font-semibold text-zinc-800 mb-0.5">{cmt.memNic || cmt.memId}</p>
+                              <p className="text-[12px] text-zinc-700 leading-snug">{cmt.cmtContent}</p>
+                              <p className="text-[10px] text-zinc-400 mt-0.5">
+                                {cmt.cmtRegDtm?.slice(0, 16)}
+                                {cmt.cmtModDtm && cmt.cmtModDtm !== cmt.cmtRegDtm && <span className="ml-1">(수정됨)</span>}
+                              </p>
+                            </div>
                           )}
                         </div>
-                        {editingCommentId === cmt.cmtId ? (
-                          <div className="flex-1 min-w-0 flex gap-2">
-                            <input
-                              value={editCommentText}
-                              onChange={(e) => setEditCommentText(e.target.value)}
-                              className="flex-1 border border-zinc-200 rounded px-2 py-1 text-[12px] outline-none focus:border-[#3B3EFF]"
-                            />
-                            <button onClick={() => updateCommentMutation.mutate({ cmtId: cmt.cmtId, cmtContent: editCommentText })} className="text-[11px] font-semibold text-[#3B3EFF] shrink-0">저장</button>
-                            <button onClick={() => setEditingCommentId(null)} className="text-[11px] text-zinc-400 shrink-0">취소</button>
-                          </div>
-                        ) : (
-                          <div className="flex-1 min-w-0">
-                            <p className="text-[11px] font-semibold text-zinc-800 mb-0.5">{cmt.memNic || cmt.memId}</p>
-                            <p className="text-[12px] text-zinc-700 leading-snug">{cmt.cmtContent}</p>
-                            <p className="text-[10px] text-zinc-400 mt-0.5">{cmt.cmtRegDtm?.slice(0, 16)}</p>
+                        {isMe && editingId !== cmt.cmtId && (
+                          <div className="shrink-0 flex items-center gap-2 pt-0.5">
+                            <button
+                              onClick={() => { setEditingId(cmt.cmtId); setEditText(cmt.cmtContent); }}
+                              className="text-[11px] text-zinc-400 hover:text-[#3B3EFF] transition-colors"
+                            >수정</button>
+                            <button
+                              onClick={() => delMut.mutate(cmt.cmtId)}
+                              disabled={delMut.isPending}
+                              className="text-[11px] text-zinc-400 hover:text-red-400 transition-colors disabled:opacity-40"
+                            >삭제</button>
                           </div>
                         )}
                       </div>
-                      {isMyComment && editingCommentId !== cmt.cmtId && (
-                        <div className="shrink-0 flex items-center gap-2 pt-0.5">
-                          <button onClick={() => { setEditingCommentId(cmt.cmtId); setEditCommentText(cmt.cmtContent); }} className="text-[11px] text-zinc-400 hover:text-[#3B3EFF] transition-colors">
-                            수정
-                          </button>
-                          <button
-                            onClick={() => deleteCommentMutation.mutate(cmt.cmtId)}
-                            className="text-[11px] text-zinc-400 hover:text-red-400 transition-colors"
-                          >
-                            삭제
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )})}
+                    );
+                  })}
                 </>
               )}
               <div className="flex gap-2">
                 <input
                   value={commentText}
-                  onChange={(e) => setCommentText(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === 'Enter' && commentText.trim()) addCommentMutation.mutate(); }}
+                  onChange={e => setCommentText(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter' && commentText.trim()) addMut.mutate(); }}
                   placeholder="댓글 입력..."
                   className="flex-1 border border-zinc-200 rounded-lg px-3 py-1.5 text-[13px] outline-none focus:border-[#3B3EFF] bg-white"
                 />
                 <button
-                  disabled={!commentText.trim() || addCommentMutation.isPending}
-                  onClick={() => addCommentMutation.mutate()}
+                  disabled={!commentText.trim() || addMut.isPending}
+                  onClick={() => addMut.mutate()}
                   className="px-3 py-1.5 bg-[#3B3EFF] text-white rounded-lg text-[12px] font-semibold disabled:bg-zinc-200 disabled:text-zinc-400"
                 >
                   등록


### PR DESCRIPTION
- 메인·홈 페이지 댓글 수정/삭제 기능 추가 (본인 수정, 본인+모임장 삭제)
- 댓글 접힘 상태에서 댓글 수 표기 (댓글 (N))
- 댓글 소유자 비교 기준 memId → userId 수정
- 미션 탭 모드 토글(관리/수행) 버튼 전환
- 리더 관리 모드: 상태 탭(전체/진행 중/완료) + 범위 칩(전체/공통/개인)
- 미션 만료 상태(expired) 추가 및 수행 모드에서 개인 미션 본인 필터링
- 제출 현황·상세 페이지 모임원 프로필 이미지 표시

## 📋 작업 내용
<!-- 어떤 작업을 했는지 설명 -->

## 🔗 관련 이슈
Closes #이슈번호

## ✅ 체크리스트
- [ ] develop 브랜치 기준으로 작업했나요?
- [ ] 로컬에서 테스트 완료했나요?
- [ ] 불필요한 코드/주석 제거했나요?

## 📷 스크린샷
<!-- API 테스트 결과 또는 UI 변경사항 -->
